### PR TITLE
Add JUCE-based AU/VST3 plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,20 @@ builds/
 .DS_Store
 */.DS_Store
 .vscode/
+
+# JUCE / C++ plugin build artifacts
+plugin/build/
+*.o
+*.a
+*.dylib
+*.so
+*.dll
+*.vst3
+*.component
+*.app
+*.xcodeproj
+*.xcworkspace
+xcuserdata/
+DerivedData/
+cmake-build-*/
+compile_commands.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugin/JUCE"]
+	path = plugin/JUCE
+	url = https://github.com/juce-framework/JUCE.git

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.22)
+project(OrcaPlugin VERSION 0.1.0)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_subdirectory(JUCE)
+
+juce_add_plugin(OrcaPlugin
+    COMPANY_NAME "Orca"
+    IS_SYNTH TRUE
+    NEEDS_MIDI_INPUT TRUE
+    NEEDS_MIDI_OUTPUT TRUE
+    IS_MIDI_EFFECT FALSE
+    PLUGIN_MANUFACTURER_CODE Orca
+    PLUGIN_CODE Orka
+    FORMATS AU VST3 Standalone
+    PRODUCT_NAME "Orca"
+    BUNDLE_ID "com.orca.plugin"
+    AU_MAIN_TYPE "kAudioUnitType_MusicDevice"
+)
+
+target_sources(OrcaPlugin
+    PRIVATE
+        Source/PluginProcessor.cpp
+        Source/PluginProcessor.h
+        Source/PluginEditor.cpp
+        Source/PluginEditor.h
+        Source/engine/Types.h
+        Source/engine/Grid.h
+        Source/engine/Grid.cpp
+        Source/engine/Operator.h
+        Source/engine/Operator.cpp
+        Source/engine/Transpose.h
+        Source/engine/MidiStack.h
+        Source/engine/CcStack.h
+        Source/engine/MonoStack.h
+        Source/engine/EngineIO.h
+        Source/engine/Engine.h
+)
+
+target_include_directories(OrcaPlugin
+    PRIVATE
+        Source
+)
+
+target_compile_definitions(OrcaPlugin
+    PUBLIC
+        JUCE_WEB_BROWSER=0
+        JUCE_USE_CURL=0
+        JUCE_VST3_CAN_REPLACE_VST2=0
+        JUCE_DISPLAY_SPLASH_SCREEN=0
+)
+
+find_library(COREMIDI_FRAMEWORK CoreMIDI)
+find_library(AUDIOTOOLBOX_FRAMEWORK AudioToolbox)
+
+target_link_libraries(OrcaPlugin
+    PRIVATE
+        juce::juce_audio_utils
+        juce::juce_gui_basics
+        ${COREMIDI_FRAMEWORK}
+        ${AUDIOTOOLBOX_FRAMEWORK}
+    PUBLIC
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_warning_flags
+)

--- a/plugin/Makefile
+++ b/plugin/Makefile
@@ -1,0 +1,37 @@
+BUILD_DIR   := build
+ARTIFACTS   := $(BUILD_DIR)/OrcaPlugin_artefacts
+# CMake may place artifacts directly or under Release/
+AU_SRC      := $(shell find $(ARTIFACTS) -name "Orca.component" -type d 2>/dev/null | head -1)
+VST3_SRC    := $(shell find $(ARTIFACTS) -name "Orca.vst3" -type d 2>/dev/null | head -1)
+AU_DST      := $(HOME)/Library/Audio/Plug-Ins/Components/Orca.component
+VST3_DST    := $(HOME)/Library/Audio/Plug-Ins/VST3/Orca.vst3
+
+.PHONY: all build install install-au install-vst3 validate clean configure
+
+all: build install
+
+configure:
+	cmake -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=Release
+
+build:
+	@test -d $(BUILD_DIR) || (echo "Run 'make configure' first" && exit 1)
+	cmake --build $(BUILD_DIR) --config Release
+
+install: install-au install-vst3
+
+install-au: build
+	rm -rf "$(AU_DST)"
+	cp -R "$(AU_SRC)" "$(AU_DST)"
+	@echo "AU installed → $(AU_DST)"
+
+install-vst3: build
+	rm -rf "$(VST3_DST)"
+	cp -R "$(VST3_SRC)" "$(VST3_DST)"
+	codesign --force --deep --sign - "$(VST3_DST)"
+	@echo "VST3 installed → $(VST3_DST)"
+
+validate: install-au
+	auval -v aumu Orka Orca
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/plugin/Source/PluginEditor.cpp
+++ b/plugin/Source/PluginEditor.cpp
@@ -1,0 +1,694 @@
+#include "PluginEditor.h"
+
+// ── GridComponent ──
+
+GridComponent::GridComponent(OrcaProcessor& p)
+    : processor(p)
+{
+    setWantsKeyboardFocus(true);
+    startTimerHz(30); // 30fps UI refresh
+
+    // Use a monospace font
+    updateFontSize(fontSize);
+}
+
+GridComponent::~GridComponent() {
+    stopTimer();
+    // Cancel any pending async file chooser to prevent callback on a dead object
+    fileChooser.reset();
+}
+
+void GridComponent::paint(juce::Graphics& g) {
+    g.fillAll(bgColor);
+
+    auto& engine = processor.engine;
+    int gridW = engine.shadowW;
+    int gridH = engine.shadowH;
+
+    g.setFont(monoFont);
+
+    for (int y = 0; y < gridH; y++) {
+        for (int x = 0; x < gridW; x++) {
+            int idx = x + gridW * y;
+            char glyph = engine.shadowCells[idx];
+            uint8_t portType = engine.shadowPorts[idx];
+            bool isLocked = engine.shadowLocks[idx];
+            bool isSelected = (x >= cursorX && x < cursorX + selectW &&
+                               y >= cursorY && y < cursorY + selectH);
+            drawCell(g, x, y, glyph, portType, isLocked, isSelected);
+        }
+    }
+
+    // Draw cursor marker on top of selection
+    {
+        float cx = cursorX * tileW;
+        float cy = cursorY * tileH;
+        g.setColour(bInv);
+        g.fillRect(cx, cy, tileW, tileH);
+        g.setColour(fInv);
+        char curGlyphUnder = '.';
+        if (cursorX < gridW && cursorY < gridH)
+            curGlyphUnder = engine.shadowCells[cursorX + gridW * cursorY];
+        char cursorChar = (curGlyphUnder != '.') ? curGlyphUnder : '@';
+        g.drawText(juce::String::charToString(cursorChar),
+                   (int)cx, (int)cy, (int)tileW, (int)tileH,
+                   juce::Justification::centred);
+    }
+
+    // Two-line status bar (matches original Orca layout)
+    g.setFont(monoFont);
+    float statusY = getHeight() - 30.0f;
+
+    // Get glyph and port info under cursor
+    char curGlyph = '.';
+    uint8_t curPort = 0;
+    char curPortOwner = 0;
+    uint8_t curPortIdx = 0;
+    if (cursorX < gridW && cursorY < gridH) {
+        int ci = cursorX + gridW * cursorY;
+        curGlyph = engine.shadowCells[ci];
+        curPort = engine.shadowPorts[ci];
+        curPortOwner = engine.shadowPortOwner[ci];
+        curPortIdx = engine.shadowPortIdx[ci];
+    }
+
+    // Line 1: operator_name (+ port_name if on a port)  cursor_pos  frame
+    {
+        g.setColour(fMed);
+        juce::String line1;
+        if (curPort > 0 && curPort != 10 && curPortOwner != 0) {
+            // Cursor is on a port — show "ownerName portName"
+            line1 << operatorName(curPortOwner) << " " << portName(curPortOwner, curPortIdx);
+        } else {
+            line1 << operatorName(curGlyph);
+        }
+        line1 << "   " << cursorX << "," << cursorY
+              << "   " << engine.shadowF << "f";
+        g.drawText(line1, 4, (int)statusY, getWidth() - 8, 14,
+                   juce::Justification::centredLeft);
+    }
+
+    // Line 2: grid_size
+    {
+        g.setColour(fLow);
+        juce::String line2;
+        line2 << gridW << "x" << gridH;
+        g.drawText(line2, 4, (int)(statusY + 14), getWidth() - 8, 14,
+                   juce::Justification::centredLeft);
+    }
+}
+
+void GridComponent::drawCell(juce::Graphics& g, int x, int y, char glyph,
+                              uint8_t portType, bool isLocked, bool isSelected) {
+    float px = x * tileW;
+    float py = y * tileH;
+
+    // Determine style type (mirrors JS makeStyle)
+    int styleType;
+    if (isSelected) {
+        styleType = 4; // selected
+    } else if (portType > 0 && portType != 10) {
+        styleType = portType; // port type from engine
+    } else if (glyph == '*' && !isLocked) {
+        styleType = 2; // bang as input
+    } else if (isLocked) {
+        styleType = 5; // locked
+    } else if (portType == 10) {
+        styleType = 0; // operator self
+    } else {
+        styleType = 20; // default
+    }
+
+    // Get colors (mirrors JS makeTheme)
+    juce::Colour bgCol, fgCol;
+    bool hasBg = false, hasFg = false;
+
+    switch (styleType) {
+        case 0:  hasBg = true; bgCol = bMed; hasFg = true; fgCol = fLow; break;  // operator
+        case 1:  hasFg = true; fgCol = bMed; break;                              // haste input
+        case 2:  hasFg = true; fgCol = bHigh; break;                             // input
+        case 3:  hasBg = true; bgCol = bHigh; hasFg = true; fgCol = fLow; break; // output
+        case 4:  hasBg = true; bgCol = bInv; hasFg = true; fgCol = fInv; break;  // selected
+        case 5:  hasFg = true; fgCol = fMed; break;                              // locked
+        case 6:  hasFg = true; fgCol = bInv; break;                              // reader
+        case 8:  hasBg = true; bgCol = bLow; hasFg = true; fgCol = fHigh; break; // bang output
+        case 9:  hasBg = true; bgCol = bInv; hasFg = true; fgCol = bgColor; break; // reader output
+        default: hasFg = true; fgCol = fLow; break;                              // default
+    }
+
+    // Handle empty cells
+    if (glyph == '.' && !hasBg && !isSelected) {
+        // Empty port cells: show a colored dot in the port color
+        if (hasFg && styleType > 0 && styleType < 20) {
+            g.setColour(fgCol);
+            float dotX = px + tileW * 0.5f;
+            float dotY = py + tileH * 0.5f;
+            g.fillRect(dotX - 0.5f, dotY - 0.5f, 2.0f, 2.0f);
+            return;
+        }
+
+        bool isMarker = (x % 8 == 0 && y % 8 == 0);
+        bool isLocalGuide = (x % 2 == 0 && y % 2 == 0) &&
+                            (std::abs(x - cursorX) <= 6 && std::abs(y - cursorY) <= 6);
+
+        if (isMarker) {
+            // Major grid markers: '+' at 8x8 intervals
+            g.setColour(fLow);
+            g.drawText("+", (int)px, (int)py, (int)tileW, (int)tileH,
+                       juce::Justification::centred);
+        } else if (isLocalGuide) {
+            // Local guide: tiny 1px dot at center of tile
+            g.setColour(fLow);
+            float dotX = px + tileW * 0.5f;
+            float dotY = py + tileH * 0.5f;
+            g.fillRect(dotX, dotY, 1.0f, 1.0f);
+        }
+        return;
+    }
+
+    // Draw background
+    if (hasBg) {
+        g.setColour(bgCol);
+        g.fillRect(px, py, tileW, tileH);
+    }
+
+    // Draw glyph (selected empty cells show '.' in selection color)
+    if (hasFg && (glyph != '.' || isSelected)) {
+        g.setColour(fgCol);
+        g.drawText(juce::String::charToString(glyph),
+                   (int)px, (int)py, (int)tileW, (int)tileH,
+                   juce::Justification::centred);
+    }
+}
+
+void GridComponent::updateFontSize(float newSize) {
+    fontSize = juce::jlimit(8.0f, 36.0f, newSize);
+    monoFont = juce::Font(juce::FontOptions(juce::Font::getDefaultMonospacedFontName(), fontSize, juce::Font::plain));
+    tileW = std::round(fontSize * 0.833f);  // ~10/12 ratio
+    tileH = std::round(fontSize * 1.25f);   // ~15/12 ratio
+}
+
+void GridComponent::resized() {
+    // Only grow the grid, never shrink (prevents losing content on resize)
+    int viewW = juce::jmax(1, (int)(getWidth() / tileW));
+    int viewH = juce::jmax(1, (int)((getHeight() - 32.0f) / tileH));
+    viewW = juce::jmin(viewW, orca::kMaxGridW);
+    viewH = juce::jmin(viewH, orca::kMaxGridH);
+
+    auto& grid = processor.engine.grid;
+    int newW = juce::jmax(grid.w, viewW);
+    int newH = juce::jmax(grid.h, viewH);
+
+    if (newW != grid.w || newH != grid.h) {
+        // Grow grid, preserving all existing content
+        char buf[orca::kMaxGridSize];
+        memcpy(buf, grid.cells, grid.w * grid.h);
+
+        char newCells[orca::kMaxGridSize];
+        for (int i = 0; i < newW * newH; i++) newCells[i] = '.';
+        for (int y = 0; y < grid.h; y++) {
+            for (int x = 0; x < grid.w; x++) {
+                newCells[x + newW * y] = buf[x + grid.w * y];
+            }
+        }
+        processor.engine.load(newW, newH, newCells, grid.f);
+    }
+}
+
+void GridComponent::timerCallback() {
+    // Always refresh shadow buffer so UI reflects edits even when DAW is stopped
+    processor.engine.updateShadow();
+    repaint();
+}
+
+bool GridComponent::keyPressed(const juce::KeyPress& key) {
+    auto& grid = processor.engine.grid;
+    int code = key.getKeyCode();
+    bool shift = key.getModifiers().isShiftDown();
+    bool cmd = key.getModifiers().isCommandDown();
+
+    // Cmd+S: save as
+    if (cmd && code == 'S') {
+        saveAs();
+        return true;
+    }
+
+    // Cmd+O: open .orca file
+    if (cmd && code == 'O') {
+        fileChooser = std::make_unique<juce::FileChooser>(
+            "Open .orca file", juce::File(), "*");
+        fileChooser->launchAsync(juce::FileBrowserComponent::openMode
+                                 | juce::FileBrowserComponent::canSelectFiles,
+            [this](const juce::FileChooser& fc) {
+                auto result = fc.getResult();
+                if (result.existsAsFile() && result.hasFileExtension("orca"))
+                    loadOrcaFile(result);
+            });
+        return true;
+    }
+
+    // Cmd+=: zoom in, Cmd+-: zoom out
+    if (cmd && (code == '+' || code == '=' || key.getTextCharacter() == '+' || key.getTextCharacter() == '=')) {
+        updateFontSize(fontSize + 1.0f);
+        if (auto* editor = findParentComponentOfClass<OrcaEditor>()) {
+            auto& grid = processor.engine.grid;
+            int newW = juce::jmax(400, (int)(grid.w * tileW) + 4);
+            int newH = juce::jmax(300, (int)(grid.h * tileH) + 32);
+            editor->setSize(newW, newH);
+        }
+        return true;
+    }
+    if (cmd && (code == '-' || key.getTextCharacter() == '-')) {
+        updateFontSize(fontSize - 1.0f);
+        if (auto* editor = findParentComponentOfClass<OrcaEditor>()) {
+            auto& grid = processor.engine.grid;
+            int newW = juce::jmax(400, (int)(grid.w * tileW) + 4);
+            int newH = juce::jmax(300, (int)(grid.h * tileH) + 32);
+            editor->setSize(newW, newH);
+        }
+        return true;
+    }
+
+    // Cmd+Z: undo, Cmd+Shift+Z: redo
+    if (cmd && code == 'Z') {
+        if (shift) redo(); else undo();
+        return true;
+    }
+
+    // Cmd+C: copy
+    if (cmd && code == 'C') {
+        clipW = selectW;
+        clipH = selectH;
+        for (int y = 0; y < clipH; y++)
+            for (int x = 0; x < clipW; x++)
+                clipboard[x + clipW * y] = grid.glyphAt(cursorX + x, cursorY + y);
+        return true;
+    }
+
+    // Cmd+X: cut
+    if (cmd && code == 'X') {
+        pushHistory();
+        clipW = selectW;
+        clipH = selectH;
+        for (int y = 0; y < clipH; y++)
+            for (int x = 0; x < clipW; x++) {
+                clipboard[x + clipW * y] = grid.glyphAt(cursorX + x, cursorY + y);
+                grid.write(cursorX + x, cursorY + y, '.');
+            }
+        return true;
+    }
+
+    // Cmd+V: paste
+    if (cmd && code == 'V') {
+        if (clipW > 0 && clipH > 0) {
+            pushHistory();
+            for (int y = 0; y < clipH; y++)
+                for (int x = 0; x < clipW; x++)
+                    grid.write(cursorX + x, cursorY + y, clipboard[x + clipW * y]);
+        }
+        return true;
+    }
+
+    // Arrow keys: move cursor or expand selection in all directions
+    if (code == juce::KeyPress::leftKey) {
+        if (shift) {
+            if (cursorX > 0) { cursorX--; selectW++; }
+        } else {
+            cursorX = juce::jmax(0, cursorX - 1); selectW = 1; selectH = 1;
+        }
+        return true;
+    }
+    if (code == juce::KeyPress::rightKey) {
+        if (shift) { selectW = juce::jmin(grid.w - cursorX, selectW + 1); }
+        else { cursorX = juce::jmin(grid.w - 1, cursorX + 1); selectW = 1; selectH = 1; }
+        return true;
+    }
+    if (code == juce::KeyPress::upKey) {
+        if (shift) {
+            if (cursorY > 0) { cursorY--; selectH++; }
+        } else {
+            cursorY = juce::jmax(0, cursorY - 1); selectW = 1; selectH = 1;
+        }
+        return true;
+    }
+    if (code == juce::KeyPress::downKey) {
+        if (shift) { selectH = juce::jmin(grid.h - cursorY, selectH + 1); }
+        else { cursorY = juce::jmin(grid.h - 1, cursorY + 1); selectW = 1; selectH = 1; }
+        return true;
+    }
+
+    // Escape: deselect
+    if (code == juce::KeyPress::escapeKey) {
+        selectW = 1; selectH = 1;
+        return true;
+    }
+
+    // Backspace/Delete: erase selection
+    if (code == juce::KeyPress::backspaceKey || code == juce::KeyPress::deleteKey) {
+        pushHistory();
+        for (int y = 0; y < selectH; y++)
+            for (int x = 0; x < selectW; x++)
+                grid.write(cursorX + x, cursorY + y, '.');
+        return true;
+    }
+
+    // Printable character: write glyph (cursor stays in place, like original Orca)
+    auto textChar = key.getTextCharacter();
+    if (textChar == '.') {
+        pushHistory();
+        grid.write(cursorX, cursorY, '.');
+        return true;
+    }
+    if (textChar != 0 && orca::isOperatorGlyph(static_cast<char>(textChar))) {
+        pushHistory();
+        grid.write(cursorX, cursorY, static_cast<char>(textChar));
+        return true;
+    }
+
+    return false;
+}
+
+void GridComponent::mouseDown(const juce::MouseEvent& event) {
+    grabKeyboardFocus();
+    dragOriginX = juce::jlimit(0, processor.engine.grid.w - 1,
+                                (int)(event.position.x / tileW));
+    dragOriginY = juce::jlimit(0, processor.engine.grid.h - 1,
+                                (int)(event.position.y / tileH));
+    cursorX = dragOriginX;
+    cursorY = dragOriginY;
+    selectW = 1;
+    selectH = 1;
+    repaint();
+}
+
+void GridComponent::mouseDrag(const juce::MouseEvent& event) {
+    int dragX = juce::jlimit(0, processor.engine.grid.w - 1,
+                              (int)(event.position.x / tileW));
+    int dragY = juce::jlimit(0, processor.engine.grid.h - 1,
+                              (int)(event.position.y / tileH));
+    // Selection works in all directions from the click origin
+    cursorX = juce::jmin(dragOriginX, dragX);
+    cursorY = juce::jmin(dragOriginY, dragY);
+    selectW = std::abs(dragX - dragOriginX) + 1;
+    selectH = std::abs(dragY - dragOriginY) + 1;
+    repaint();
+}
+
+// ── Undo/Redo ──
+
+void GridComponent::pushHistory() {
+    // Discard any redo history beyond current position
+    if (historyPos < historyCount - 1)
+        historyCount = historyPos + 1;
+
+    // If full, shift everything left
+    if (historyCount >= kMaxHistory) {
+        for (int i = 0; i < kMaxHistory - 1; i++)
+            history[i] = history[i + 1];
+        historyCount = kMaxHistory - 1;
+    }
+
+    auto& snap = history[historyCount];
+    auto& grid = processor.engine.grid;
+    memcpy(snap.cells, grid.cells, grid.w * grid.h);
+    snap.w = grid.w;
+    snap.h = grid.h;
+    historyCount++;
+    historyPos = historyCount - 1;
+}
+
+void GridComponent::undo() {
+    if (historyPos <= 0) return;
+    historyPos--;
+    auto& snap = history[historyPos];
+    processor.engine.load(snap.w, snap.h, snap.cells, processor.engine.grid.f);
+}
+
+void GridComponent::redo() {
+    if (historyPos >= historyCount - 1) return;
+    historyPos++;
+    auto& snap = history[historyPos];
+    processor.engine.load(snap.w, snap.h, snap.cells, processor.engine.grid.f);
+}
+
+// ── File loading ──
+
+bool GridComponent::isInterestedInFileDrag(const juce::StringArray& files) {
+    for (auto& f : files)
+        if (f.endsWith(".orca")) return true;
+    return false;
+}
+
+void GridComponent::filesDropped(const juce::StringArray& files, int /*x*/, int /*y*/) {
+    for (auto& f : files) {
+        if (f.endsWith(".orca")) {
+            loadOrcaFile(juce::File(f));
+            break;
+        }
+    }
+}
+
+void GridComponent::loadOrcaFile(const juce::File& file) {
+    auto content = file.loadFileAsString();
+    if (content.isEmpty()) return;
+
+    // Parse .orca format: lines of characters
+    auto lines = juce::StringArray::fromLines(content);
+
+    // Remove trailing empty lines
+    while (lines.size() > 0 && lines[lines.size() - 1].trimEnd().isEmpty())
+        lines.remove(lines.size() - 1);
+
+    if (lines.isEmpty()) return;
+
+    // Find dimensions
+    int h = lines.size();
+    int w = 0;
+    for (auto& line : lines)
+        w = juce::jmax(w, line.length());
+
+    w = juce::jmin(w, orca::kMaxGridW);
+    h = juce::jmin(h, orca::kMaxGridH);
+
+    // Build flat grid string
+    char buf[orca::kMaxGridSize];
+    for (int i = 0; i < w * h; i++) buf[i] = '.';
+
+    for (int y = 0; y < h; y++) {
+        auto& line = lines[y];
+        for (int x = 0; x < w && x < line.length(); x++) {
+            char c = static_cast<char>(line[x]);
+            buf[x + w * y] = c;
+        }
+    }
+
+    processor.engine.load(w, h, buf, 0);
+    currentFile = file;
+
+    // Resize window to fit
+    if (auto* editor = findParentComponentOfClass<OrcaEditor>()) {
+        int newWidth = (int)(w * tileW) + 4;
+        int newHeight = (int)(h * tileH) + 24;
+        editor->setSize(juce::jmax(400, newWidth), juce::jmax(300, newHeight));
+    }
+}
+
+// ── Save .orca file ──
+
+void GridComponent::saveOrcaFile(const juce::File& file) {
+    auto& grid = processor.engine.grid;
+    char buf[orca::kMaxGridSize + orca::kMaxGridH]; // grid + newlines
+    int len = grid.format(buf, sizeof(buf));
+    file.replaceWithData(buf, (size_t)len);
+    currentFile = file;
+}
+
+void GridComponent::saveAs() {
+    fileChooser = std::make_unique<juce::FileChooser>(
+        "Save .orca file", currentFile.existsAsFile() ? currentFile : juce::File(), "*.orca");
+    fileChooser->launchAsync(juce::FileBrowserComponent::saveMode
+                             | juce::FileBrowserComponent::canSelectFiles,
+        [this](const juce::FileChooser& fc) {
+            auto result = fc.getResult();
+            if (result != juce::File())
+                saveOrcaFile(result.withFileExtension("orca"));
+        });
+}
+
+// ── Operator name lookup ──
+
+const char* GridComponent::operatorName(char glyph) {
+    switch (orca::toLower(glyph)) {
+        case 'a': return "add";       case 'b': return "subtract";
+        case 'c': return "clock";     case 'd': return "delay";
+        case 'e': return "east";      case 'f': return "if";
+        case 'g': return "generator"; case 'h': return "halt";
+        case 'i': return "increment"; case 'j': return "jumper";
+        case 'k': return "konkat";    case 'l': return "lesser";
+        case 'm': return "multiply";  case 'n': return "north";
+        case 'o': return "read";      case 'p': return "push";
+        case 'q': return "query";     case 'r': return "random";
+        case 's': return "south";     case 't': return "track";
+        case 'u': return "uclid";     case 'v': return "variable";
+        case 'w': return "west";      case 'x': return "write";
+        case 'y': return "jymper";    case 'z': return "lerp";
+        case ':': return "midi";      case '!': return "cc";
+        case '?': return "pb";        case '%': return "mono";
+        case '=': return "osc";       case ';': return "udp";
+        case '*': return "bang";      case '#': return "comment";
+        default:  return "empty";
+    }
+}
+
+// ── Port name lookup ──
+
+const char* GridComponent::portName(char ownerGlyph, int portIdx) {
+    // Port names match the original Orca JS library port definitions.
+    // portIdx corresponds to the slot in OperatorInstance::ports[].
+    char g = orca::toLower(ownerGlyph);
+
+    // Letter operators with (a, b, output) pattern: a, b, f, l, m, r
+    if (g == 'a' || g == 'b' || g == 'f' || g == 'l' || g == 'm' || g == 'r') {
+        switch (portIdx) {
+            case 0: return "a";  case 1: return "b";  case 2: return "output";
+        }
+    }
+
+    // Rate/mod/output pattern: c, d
+    if (g == 'c' || g == 'd') {
+        switch (portIdx) {
+            case 0: return "rate";  case 1: return "mod";  case 2: return "output";
+        }
+    }
+
+    // Step/mod/output: i
+    if (g == 'i') {
+        switch (portIdx) {
+            case 0: return "step";  case 1: return "mod";  case 2: return "output";
+        }
+    }
+
+    // Step/max/output: u
+    if (g == 'u') {
+        switch (portIdx) {
+            case 0: return "step";  case 1: return "max";  case 2: return "output";
+        }
+    }
+
+    // Rate/target/output: z
+    if (g == 'z') {
+        switch (portIdx) {
+            case 0: return "rate";  case 1: return "target";  case 2: return "output";
+        }
+    }
+
+    // x/y/len: g, q
+    if (g == 'g' || g == 'q') {
+        switch (portIdx) {
+            case 0: return "x";  case 1: return "y";  case 2: return "len";
+        }
+    }
+
+    // x/y/output: o
+    if (g == 'o') {
+        switch (portIdx) {
+            case 0: return "x";  case 1: return "y";  case 2: return "output";
+        }
+    }
+
+    // key/len/val: p
+    if (g == 'p') {
+        switch (portIdx) {
+            case 0: return "key";  case 1: return "len";  case 2: return "val";  case 3: return "output";
+        }
+    }
+
+    // key/len/output: t
+    if (g == 't') {
+        switch (portIdx) {
+            case 0: return "key";  case 1: return "len";  case 2: return "output";
+        }
+    }
+
+    // x/y/val: x
+    if (g == 'x') {
+        switch (portIdx) {
+            case 0: return "x";  case 1: return "y";  case 2: return "val";  case 3: return "output";
+        }
+    }
+
+    // write/read: v
+    if (g == 'v') {
+        switch (portIdx) {
+            case 0: return "write";  case 1: return "read";  case 2: return "output";
+        }
+    }
+
+    // halt: h
+    if (g == 'h') {
+        if (portIdx == 2) return "output";
+    }
+
+    // konkat: k
+    if (g == 'k') {
+        if (portIdx == 0) return "len";
+    }
+
+    // MIDI operators: : and %
+    if (g == ':' || g == '%') {
+        switch (portIdx) {
+            case 0: return "channel";  case 1: return "octave";  case 2: return "note";
+            case 3: return "velocity"; case 4: return "length";
+        }
+    }
+
+    // CC: !
+    if (g == '!') {
+        switch (portIdx) {
+            case 0: return "channel";  case 1: return "knob";  case 2: return "value";
+        }
+    }
+
+    // Pitch bend: ?
+    if (g == '?') {
+        switch (portIdx) {
+            case 0: return "channel";  case 1: return "lsb";  case 2: return "msb";
+        }
+    }
+
+    // Jumper/jymper: j, y — dynamic ports
+    if (g == 'j' || g == 'y') {
+        switch (portIdx) {
+            case 0: return "input";  case 1: return "output";
+        }
+    }
+
+    return "";
+}
+
+// ── OrcaEditor ──
+
+OrcaEditor::OrcaEditor(OrcaProcessor& p)
+    : AudioProcessorEditor(&p), orcaProcessor(p), gridComponent(p)
+{
+    addAndMakeVisible(gridComponent);
+    setSize(p.editorWidth, p.editorHeight);
+    setResizable(true, true);
+}
+
+OrcaEditor::~OrcaEditor() {
+    // Remove the grid component before this editor is destroyed,
+    // so its destructor runs while the processor reference is still valid.
+    removeChildComponent(&gridComponent);
+}
+
+void OrcaEditor::paint(juce::Graphics& g) {
+    g.fillAll(juce::Colour(0xff000000));
+}
+
+void OrcaEditor::resized() {
+    gridComponent.setBounds(getLocalBounds());
+    // Persist window size so it restores when reopened
+    orcaProcessor.editorWidth = getWidth();
+    orcaProcessor.editorHeight = getHeight();
+}

--- a/plugin/Source/PluginEditor.h
+++ b/plugin/Source/PluginEditor.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "PluginProcessor.h"
+#include "engine/Operator.h"
+
+class GridComponent : public juce::Component,
+                      public juce::Timer,
+                      public juce::FileDragAndDropTarget {
+public:
+    GridComponent(OrcaProcessor& p);
+    ~GridComponent() override;
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+    void timerCallback() override;
+
+    // Keyboard input
+    bool keyPressed(const juce::KeyPress& key) override;
+    void mouseDown(const juce::MouseEvent& event) override;
+    void mouseDrag(const juce::MouseEvent& event) override;
+
+    // File drag and drop
+    bool isInterestedInFileDrag(const juce::StringArray& files) override;
+    void filesDropped(const juce::StringArray& files, int x, int y) override;
+    void loadOrcaFile(const juce::File& file);
+    void saveOrcaFile(const juce::File& file);
+    void saveAs();
+
+    juce::File currentFile; // currently loaded/saved file path
+
+    // Cursor
+    int cursorX = 0, cursorY = 0;
+    int selectW = 1, selectH = 1;
+    int dragOriginX = 0, dragOriginY = 0;
+
+    // Clipboard
+    char clipboard[orca::kMaxGridSize];
+    int clipW = 0, clipH = 0;
+
+    // Undo/Redo
+    static constexpr int kMaxHistory = 128;
+    struct Snapshot {
+        char cells[orca::kMaxGridSize];
+        int w, h;
+    };
+    Snapshot history[kMaxHistory];
+    int historyCount = 0;
+    int historyPos = -1;
+    void pushHistory();
+    void undo();
+    void redo();
+
+private:
+    OrcaProcessor& processor;
+
+    float fontSize = 12.0f;
+    float tileW = 10.0f;
+    float tileH = 15.0f;
+    void updateFontSize(float newSize);
+
+    // Theme colors (matches Orca dark theme from client.js)
+    juce::Colour bgColor      { 0xff000000 };
+    juce::Colour fHigh        { 0xffffffff };
+    juce::Colour fMed         { 0xff777777 };
+    juce::Colour fLow         { 0xff444444 };
+    juce::Colour fInv         { 0xff000000 };
+    juce::Colour bHigh        { 0xffeeeeee };
+    juce::Colour bMed         { 0xff72dec2 };
+    juce::Colour bLow         { 0xff444444 };
+    juce::Colour bInv         { 0xffffb545 };
+
+    juce::Font monoFont;
+    std::unique_ptr<juce::FileChooser> fileChooser;
+
+    void drawCell(juce::Graphics& g, int x, int y, char glyph,
+                  uint8_t portType, bool isLocked, bool isSelected);
+
+    static const char* operatorName(char glyph);
+    static const char* portName(char ownerGlyph, int portIdx);
+};
+
+class OrcaEditor : public juce::AudioProcessorEditor {
+public:
+    OrcaEditor(OrcaProcessor&);
+    ~OrcaEditor() override;
+
+    void paint(juce::Graphics&) override;
+    void resized() override;
+
+private:
+    OrcaProcessor& orcaProcessor;
+    GridComponent gridComponent;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OrcaEditor)
+};

--- a/plugin/Source/PluginProcessor.cpp
+++ b/plugin/Source/PluginProcessor.cpp
@@ -1,0 +1,184 @@
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+#include <mach/mach_time.h>
+
+OrcaProcessor::OrcaProcessor()
+    : AudioProcessor(BusesProperties()
+                     .withOutput("Output", juce::AudioChannelSet::stereo(), true))
+{
+    engine.reset(25, 25);
+
+    // Create virtual MIDI port via CoreMIDI C API (bypasses JUCE's broken singleton)
+    OSStatus status = MIDIClientCreate(CFSTR("OrcaPlugin"), nullptr, nullptr, &midiClient);
+    if (status == noErr)
+        MIDISourceCreate(midiClient, CFSTR("Orca"), &midiEndpoint);
+}
+
+OrcaProcessor::~OrcaProcessor() {
+    if (midiEndpoint) MIDIEndpointDispose(midiEndpoint);
+    if (midiClient)   MIDIClientDispose(midiClient);
+    midiEndpoint = 0;
+    midiClient = 0;
+}
+
+void OrcaProcessor::sendMidiToVirtualPort(const uint8_t* data, int numBytes) {
+    if (!midiEndpoint || numBytes <= 0) return;
+
+    MIDIPacketList packetList;
+    MIDIPacket* packet = MIDIPacketListInit(&packetList);
+    packet = MIDIPacketListAdd(&packetList, sizeof(packetList), packet,
+                               mach_absolute_time(), numBytes, data);
+    if (packet)
+        MIDIReceived(midiEndpoint, &packetList);
+}
+
+const juce::String OrcaProcessor::getName() const { return JucePlugin_Name; }
+bool OrcaProcessor::acceptsMidi() const { return true; }
+bool OrcaProcessor::producesMidi() const { return true; }
+bool OrcaProcessor::isMidiEffect() const { return false; }
+double OrcaProcessor::getTailLengthSeconds() const { return 0.0; }
+int OrcaProcessor::getNumPrograms() { return 1; }
+int OrcaProcessor::getCurrentProgram() { return 0; }
+void OrcaProcessor::setCurrentProgram(int) {}
+const juce::String OrcaProcessor::getProgramName(int) { return {}; }
+void OrcaProcessor::changeProgramName(int, const juce::String&) {}
+
+void OrcaProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
+    currentSampleRate = sampleRate;
+    currentBlockSize = samplesPerBlock;
+    frameAccumulator = 0.0;
+}
+
+void OrcaProcessor::releaseResources() {}
+
+bool OrcaProcessor::isBusesLayoutSupported(const BusesLayout& layouts) const {
+    return layouts.getMainOutputChannelSet() == juce::AudioChannelSet::stereo();
+}
+
+void OrcaProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) {
+    buffer.clear(); // synth outputs silence
+
+    // Get DAW transport state
+    double bpm = 120.0;
+    bool isPlaying = false;
+    bool hasPpq = false;
+    double ppqPosition = 0.0;
+
+    if (auto* playHead = getPlayHead()) {
+        if (auto pos = playHead->getPosition()) {
+            if (auto b = pos->getBpm())
+                bpm = *b;
+            isPlaying = pos->getIsPlaying();
+            if (auto ppq = pos->getPpqPosition()) {
+                hasPpq = true;
+                ppqPosition = *ppq;
+            }
+        }
+    }
+
+    // Reset frames when DAW transport stops
+    if (!isPlaying) {
+        if (wasPlaying) {
+            engine.grid.f = 0;
+            frameAccumulator = 0.0;
+            lastPpqFrame = -1;
+            wasPlaying = false;
+        }
+        return;
+    }
+    wasPlaying = true;
+
+    // Helper to dispatch MIDI events from a step
+    auto dispatchEvents = [&](int sampleOffset) {
+        orca::MidiEvent events[orca::kMaxEvents];
+        int eventCount = engine.step(events, orca::kMaxEvents);
+        for (int i = 0; i < eventCount; i++) {
+            auto& e = events[i];
+            midiMessages.addEvent(e.bytes, e.numBytes,
+                                   juce::jmin(sampleOffset, buffer.getNumSamples() - 1));
+            sendMidiToVirtualPort(e.bytes, e.numBytes);
+            if (e.numBytes >= 3 && (e.bytes[0] & 0xF0) == 0x90 && e.bytes[2] > 0) {
+                midiNoteOnCount.fetch_add(1, std::memory_order_relaxed);
+                lastNoteOnPitch.store(e.bytes[1], std::memory_order_relaxed);
+            }
+        }
+    };
+
+    if (hasPpq) {
+        // PPQ-based sync: 1 Orca frame = 1 sixteenth note = 0.25 PPQ
+        // Derive frame directly from DAW position — no drift possible
+        double samplesPerStep = currentSampleRate * 60.0 / (bpm * 4.0);
+        int numSamples = buffer.getNumSamples();
+        double ppqPerSample = bpm / (60.0 * currentSampleRate);
+
+        for (int s = 0; s < numSamples; s++) {
+            double ppq = ppqPosition + s * ppqPerSample;
+            int ppqFrame = static_cast<int>(std::floor(ppq * 4.0)); // 4 sixteenths per beat
+            if (ppqFrame != lastPpqFrame) {
+                lastPpqFrame = ppqFrame;
+                engine.grid.f = ppqFrame; // sync frame counter to DAW
+                dispatchEvents(s);
+            }
+        }
+    } else {
+        // Fallback: accumulator-based timing (no PPQ available)
+        double samplesPerStep = currentSampleRate * 60.0 / (bpm * 4.0);
+        int numSamples = buffer.getNumSamples();
+
+        int samplePos = 0;
+        while (samplePos < numSamples) {
+            double samplesToNext = samplesPerStep - frameAccumulator;
+            int samplesToNextInt = static_cast<int>(std::ceil(samplesToNext));
+
+            if (samplePos + samplesToNextInt <= numSamples) {
+                samplePos += samplesToNextInt;
+                frameAccumulator = 0.0;
+                dispatchEvents(samplePos);
+            } else {
+                frameAccumulator += static_cast<double>(numSamples - samplePos);
+                break;
+            }
+        }
+    }
+}
+
+juce::AudioProcessorEditor* OrcaProcessor::createEditor() {
+    return new OrcaEditor(*this);
+}
+
+bool OrcaProcessor::hasEditor() const { return true; }
+
+void OrcaProcessor::getStateInformation(juce::MemoryBlock& destData) {
+    auto xml = std::make_unique<juce::XmlElement>("OrcaState");
+    xml->setAttribute("w", engine.grid.w);
+    xml->setAttribute("h", engine.grid.h);
+    xml->setAttribute("f", engine.grid.f);
+
+    // Save grid content as string
+    juce::String gridStr;
+    int size = engine.grid.w * engine.grid.h;
+    for (int i = 0; i < size; i++)
+        gridStr += juce::String::charToString(engine.grid.cells[i]);
+    xml->setAttribute("grid", gridStr);
+    xml->setAttribute("editorW", editorWidth);
+    xml->setAttribute("editorH", editorHeight);
+
+    copyXmlToBinary(*xml, destData);
+}
+
+void OrcaProcessor::setStateInformation(const void* data, int sizeInBytes) {
+    auto xml = getXmlFromBinary(data, sizeInBytes);
+    if (xml && xml->hasTagName("OrcaState")) {
+        int w = xml->getIntAttribute("w", 25);
+        int h = xml->getIntAttribute("h", 25);
+        int f = xml->getIntAttribute("f", 0);
+        auto gridStr = xml->getStringAttribute("grid");
+        engine.load(w, h, gridStr.toRawUTF8(), f);
+        editorWidth = xml->getIntAttribute("editorW", 800);
+        editorHeight = xml->getIntAttribute("editorH", 600);
+    }
+}
+
+juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter() {
+    return new OrcaProcessor();
+}

--- a/plugin/Source/PluginProcessor.h
+++ b/plugin/Source/PluginProcessor.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <atomic>
+#include <CoreMIDI/CoreMIDI.h>
+#include "engine/Engine.h"
+
+class OrcaProcessor : public juce::AudioProcessor {
+public:
+    OrcaProcessor();
+    ~OrcaProcessor() override;
+
+    void prepareToPlay(double sampleRate, int samplesPerBlock) override;
+    void releaseResources() override;
+
+    bool isBusesLayoutSupported(const BusesLayout& layouts) const override;
+
+    void processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+
+    juce::AudioProcessorEditor* createEditor() override;
+    bool hasEditor() const override;
+
+    const juce::String getName() const override;
+
+    bool acceptsMidi() const override;
+    bool producesMidi() const override;
+    bool isMidiEffect() const override;
+    double getTailLengthSeconds() const override;
+
+    int getNumPrograms() override;
+    int getCurrentProgram() override;
+    void setCurrentProgram(int index) override;
+    const juce::String getProgramName(int index) override;
+    void changeProgramName(int index, const juce::String& newName) override;
+
+    void getStateInformation(juce::MemoryBlock& destData) override;
+    void setStateInformation(const void* data, int sizeInBytes) override;
+
+    orca::Engine engine;
+
+    // Virtual MIDI output via CoreMIDI (bypasses JUCE's broken singleton)
+    MIDIClientRef midiClient = 0;
+    MIDIEndpointRef midiEndpoint = 0;
+    void sendMidiToVirtualPort(const uint8_t* data, int numBytes);
+
+    // Debug: count MIDI events for UI display
+    std::atomic<int> midiNoteOnCount { 0 };
+    std::atomic<int> lastNoteOnPitch { -1 };
+
+    // Persisted editor window size
+    int editorWidth = 800, editorHeight = 600;
+
+private:
+    double currentSampleRate = 44100.0;
+    int    currentBlockSize  = 512;
+    double frameAccumulator  = 0.0;
+    bool   wasPlaying        = false;
+    int    lastPpqFrame      = -1;  // last frame derived from PPQ
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OrcaProcessor)
+};

--- a/plugin/Source/engine/CcStack.h
+++ b/plugin/Source/engine/CcStack.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "Types.h"
+
+namespace orca {
+
+class CcStack {
+public:
+    CcEntry entries[kMaxCCs];
+    int count = 0;
+    int offset = 64;
+
+    void clear() {
+        count = 0;
+    }
+
+    void pushCC(int channel, int knob, int value) {
+        if (count >= kMaxCCs) return;
+        auto& e = entries[count++];
+        e.type = CcEntry::TypeCC;
+        e.channel = channel;
+        e.knob = knob;
+        e.value = value;
+        e.active = true;
+    }
+
+    void pushPB(int channel, int lsb, int msb) {
+        if (count >= kMaxCCs) return;
+        auto& e = entries[count++];
+        e.type = CcEntry::TypePB;
+        e.channel = channel;
+        e.lsb = lsb;
+        e.msb = msb;
+        e.active = true;
+    }
+
+    int run(MidiEvent* outEvents, int maxEvents) {
+        int eventCount = 0;
+        for (int i = 0; i < count; i++) {
+            if (!entries[i].active) continue;
+            if (entries[i].type == CcEntry::TypeCC && eventCount < maxEvents) {
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::CC;
+                e.bytes[0] = static_cast<uint8_t>(0xB0 + entries[i].channel);
+                e.bytes[1] = static_cast<uint8_t>(offset + entries[i].knob);
+                e.bytes[2] = static_cast<uint8_t>(entries[i].value);
+                e.numBytes = 3;
+            } else if (entries[i].type == CcEntry::TypePB && eventCount < maxEvents) {
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::PitchBend;
+                e.bytes[0] = static_cast<uint8_t>(0xE0 + entries[i].channel);
+                e.bytes[1] = static_cast<uint8_t>(entries[i].lsb);
+                e.bytes[2] = static_cast<uint8_t>(entries[i].msb);
+                e.numBytes = 3;
+            }
+        }
+        return eventCount;
+    }
+
+    void setOffset(int newOffset) {
+        offset = newOffset;
+    }
+};
+
+} // namespace orca

--- a/plugin/Source/engine/Engine.h
+++ b/plugin/Source/engine/Engine.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "Grid.h"
+#include "Operator.h"
+#include "EngineIO.h"
+#include <cstdlib>
+#include <ctime>
+
+namespace orca {
+
+class Engine {
+public:
+    Grid grid;
+    EngineIO io;
+
+    // Shadow buffer for thread-safe UI reads
+    char shadowCells[kMaxGridSize];
+    // Port types for UI: 0=none, 1=haste(input left/up), 2=input, 3=output, 5=locked, 8=bang output
+    uint8_t shadowPorts[kMaxGridSize];
+    // Port owner glyph and port index (for UI port name display)
+    char shadowPortOwner[kMaxGridSize];
+    uint8_t shadowPortIdx[kMaxGridSize];
+    bool shadowLocks[kMaxGridSize];
+    int shadowW = 0, shadowH = 0, shadowF = 0;
+
+    Engine() {
+        std::srand(static_cast<unsigned>(std::time(nullptr)));
+        grid.io = &io;
+        grid.reset(25, 25);
+        updateShadow();
+    }
+
+    void reset(int w = 25, int h = 25) {
+        grid.reset(w, h);
+        updateShadow();
+    }
+
+    void load(int w, int h, const char* s, int f = 0) {
+        grid.load(w, h, s, f);
+        updateShadow();
+    }
+
+    // Execute one frame. Returns MIDI events.
+    int step(MidiEvent* outEvents, int maxEvents) {
+        io.clear();
+        grid.run();
+        int count = io.run(outEvents, maxEvents);
+        updateShadow();
+        return count;
+    }
+
+    void updateShadow() {
+        // Re-parse operators so port info is always up-to-date (even when stopped)
+        grid.parse();
+
+        int size = grid.w * grid.h;
+        memcpy(shadowCells, grid.cells, size);
+        memcpy(shadowLocks, grid.locks, size * sizeof(bool));
+        shadowW = grid.w;
+        shadowH = grid.h;
+        shadowF = grid.f;
+
+        // Build port map from runtime operators
+        memset(shadowPorts, 0, size);
+        memset(shadowPortOwner, 0, size);
+        memset(shadowPortIdx, 0, size);
+        for (int i = 0; i < grid.runtimeCount; i++) {
+            auto& op = grid.runtime[i];
+            if (grid.lockAt(op.x, op.y)) continue;
+
+            // Mark operator itself (type 0) if it draws
+            if (op.draw) {
+                int idx = grid.indexAt(op.x, op.y);
+                if (idx >= 0) shadowPorts[idx] = 10; // operator marker
+            }
+
+            // Mark ports
+            for (int p = 0; p < op.portCount; p++) {
+                if (!op.ports[p].active) continue;
+                int px = op.x + op.ports[p].x;
+                int py = op.y + op.ports[p].y;
+                int idx = grid.indexAt(px, py);
+                if (idx < 0) continue;
+
+                uint8_t portType;
+                if (op.ports[p].output) {
+                    if (op.ports[p].bang) portType = 8;        // bang output
+                    else if (op.ports[p].reader) portType = 9; // reader output
+                    else portType = 3;                          // output
+                } else if (op.ports[p].x < 0 || op.ports[p].y < 0) {
+                    portType = 1; // haste (input west/north)
+                } else {
+                    portType = 2; // input
+                }
+                shadowPorts[idx] = portType;
+                shadowPortOwner[idx] = op.glyph;
+                shadowPortIdx[idx] = static_cast<uint8_t>(p);
+            }
+        }
+    }
+};
+
+} // namespace orca

--- a/plugin/Source/engine/EngineIO.h
+++ b/plugin/Source/engine/EngineIO.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "Types.h"
+#include "MidiStack.h"
+#include "CcStack.h"
+#include "MonoStack.h"
+
+namespace orca {
+
+class EngineIO {
+public:
+    MidiStack midi;
+    CcStack cc;
+    MonoStack mono;
+
+    void clear() {
+        midi.clear();
+        cc.clear();
+        mono.clear();
+    }
+
+    // Collect all MIDI events from all stacks into output buffer
+    // Returns total number of events
+    int run(MidiEvent* outEvents, int maxEvents) {
+        int total = 0;
+
+        // Process note stack
+        int midiEvents = midi.run(outEvents + total, maxEvents - total);
+        total += midiEvents;
+
+        // Process CC stack
+        int ccEvents = cc.run(outEvents + total, maxEvents - total);
+        total += ccEvents;
+
+        // Process mono stack
+        int monoEvents = mono.run(outEvents + total, maxEvents - total);
+        total += monoEvents;
+
+        return total;
+    }
+
+    void silence(MidiEvent* outEvents, int maxEvents, int& eventCount) {
+        midi.silence(outEvents, maxEvents, eventCount);
+        mono.silence(outEvents, maxEvents, eventCount);
+    }
+};
+
+} // namespace orca

--- a/plugin/Source/engine/Grid.cpp
+++ b/plugin/Source/engine/Grid.cpp
@@ -1,0 +1,209 @@
+#include "Grid.h"
+#include "Operator.h"
+#include "EngineIO.h"
+#include <cstring>
+
+namespace orca {
+
+Grid::Grid() {
+    runtimeCount = 0;
+    reset();
+}
+
+void Grid::reset(int newW, int newH) {
+    w = newW;
+    h = newH;
+    f = 0;
+    int size = w * h;
+    for (int i = 0; i < size; i++) cells[i] = '.';
+    for (int i = size; i < kMaxGridSize; i++) cells[i] = 0;
+    memset(locks, 0, sizeof(locks));
+    memset(variables, '.', sizeof(variables));
+}
+
+void Grid::load(int newW, int newH, const char* s, int frame) {
+    w = newW;
+    h = newH;
+    f = frame;
+    int size = w * h;
+    int srcLen = s ? (int)strlen(s) : 0;
+
+    for (int i = 0; i < size; i++) {
+        if (i < srcLen) {
+            char g = s[i];
+            if (g == '\n' || g == '\r') {
+                cells[i] = '.';
+            } else if (!isAllowed(g)) {
+                cells[i] = '.';
+            } else {
+                cells[i] = g;
+            }
+        } else {
+            cells[i] = '.';
+        }
+    }
+}
+
+void Grid::run() {
+    parse();
+    operate();
+    f++;
+}
+
+// Grid access
+
+char Grid::glyphAt(int x, int y) const {
+    int idx = indexAt(x, y);
+    if (idx < 0) return '.';
+    return cells[idx];
+}
+
+int Grid::valueAt(int x, int y) const {
+    return valOfGlyph(glyphAt(x, y));
+}
+
+bool Grid::inBounds(int x, int y) const {
+    return x >= 0 && x < w && y >= 0 && y < h;
+}
+
+int Grid::indexAt(int x, int y) const {
+    if (!inBounds(x, y)) return -1;
+    return x + (w * y);
+}
+
+bool Grid::write(int x, int y, char g) {
+    if (g == 0) return false;
+    if (!inBounds(x, y)) return false;
+    if (glyphAt(x, y) == g) return false;
+    int idx = indexAt(x, y);
+    cells[idx] = isAllowed(g) ? g : '.';
+    return true;
+}
+
+// Locks
+
+void Grid::release() {
+    int size = w * h;
+    memset(locks, 0, size * sizeof(bool));
+    memset(variables, '.', sizeof(variables));
+}
+
+void Grid::lock(int x, int y) {
+    int idx = indexAt(x, y);
+    if (idx < 0) return;
+    locks[idx] = true;
+}
+
+void Grid::unlock(int x, int y) {
+    int idx = indexAt(x, y);
+    if (idx < 0) return;
+    locks[idx] = false;
+}
+
+bool Grid::lockAt(int x, int y) const {
+    int idx = indexAt(x, y);
+    if (idx < 0) return false;
+    return locks[idx];
+}
+
+// Variables
+
+char Grid::valueIn(char key) const {
+    uint8_t idx = static_cast<uint8_t>(key);
+    if (idx >= 128) return '.';
+    char v = variables[idx];
+    return v ? v : '.';
+}
+
+// Helpers
+
+bool Grid::isAllowed(char g) const {
+    if (g == '.') return true;
+    return isOperatorGlyph(g);
+}
+
+char Grid::keyOfVal(int val, bool uc) const {
+    int idx = ((val % kNumKeys) + kNumKeys) % kNumKeys;
+    char c = kKeys[idx];
+    return uc ? toUpper(c) : c;
+}
+
+int Grid::valOfGlyph(char g) const {
+    return valueOf(g);
+}
+
+// Block operations
+
+void Grid::getBlock(int x, int y, int bw, int bh, char* out, int outSize) const {
+    int pos = 0;
+    for (int _y = y; _y < y + bh && pos < outSize - 1; _y++) {
+        for (int _x = x; _x < x + bw && pos < outSize - 1; _x++) {
+            out[pos++] = glyphAt(_x, _y);
+        }
+        if (pos < outSize - 1) out[pos++] = '\n';
+    }
+    out[pos] = 0;
+}
+
+void Grid::writeBlock(int x, int y, const char* block, bool overlap) {
+    if (!block) return;
+    int _x = x, _y = y;
+    for (int i = 0; block[i] != 0; i++) {
+        if (block[i] == '\n') {
+            _y++;
+            _x = x;
+            continue;
+        }
+        char g = block[i];
+        if (overlap && g == '.') {
+            g = glyphAt(_x, _y);
+        }
+        write(_x, _y, g);
+        _x++;
+    }
+}
+
+// Formatting
+
+int Grid::format(char* out, int outSize) const {
+    int pos = 0;
+    for (int y = 0; y < h && pos < outSize - 1; y++) {
+        for (int x = 0; x < w && pos < outSize - 1; x++) {
+            out[pos++] = glyphAt(x, y);
+        }
+        if (pos < outSize - 1) out[pos++] = '\n';
+    }
+    out[pos] = 0;
+    return pos;
+}
+
+// Internal
+
+void Grid::parse() {
+    runtimeCount = 0;
+    for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+            char g = glyphAt(x, y);
+            if (g == '.' || !isAllowed(g)) continue;
+            if (runtimeCount >= kMaxOperators) break;
+
+            bool isPassive = isUpper(g) || isSpecial(g);
+            if (createOperator(runtime[runtimeCount], g, x, y, isPassive)) {
+                runtimeCount++;
+            }
+        }
+    }
+}
+
+void Grid::operate() {
+    release();
+    for (int i = 0; i < runtimeCount; i++) {
+        auto& op = runtime[i];
+        if (lockAt(op.x, op.y)) continue;
+        if (op.passive || op.hasNeighbor(*this, '*')) {
+            op.run(*this, *io, false);
+        }
+    }
+}
+
+} // namespace orca

--- a/plugin/Source/engine/Grid.h
+++ b/plugin/Source/engine/Grid.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "Types.h"
+#include "Operator.h"
+
+namespace orca {
+class EngineIO;
+
+class Grid {
+public:
+    int w = 1;
+    int h = 1;
+    int f = 0;
+
+    char cells[kMaxGridSize];
+    bool locks[kMaxGridSize];
+    char variables[128]; // indexed by char value, stores glyph
+
+    OperatorInstance runtimeStorage[kMaxOperators];
+    OperatorInstance* runtime = runtimeStorage;
+    int runtimeCount = 0;
+    EngineIO* io = nullptr;
+
+    Grid();
+
+    void reset(int newW = 25, int newH = 25);
+    void load(int newW, int newH, const char* s, int frame = 0);
+    void run();
+
+    // Grid access
+    char glyphAt(int x, int y) const;
+    int valueAt(int x, int y) const;
+    bool inBounds(int x, int y) const;
+    int indexAt(int x, int y) const;
+    bool write(int x, int y, char g);
+
+    // Locks
+    void release();
+    void lock(int x, int y);
+    void unlock(int x, int y);
+    bool lockAt(int x, int y) const;
+
+    // Variables
+    char valueIn(char key) const;
+
+    // Helpers
+    bool isAllowed(char g) const;
+    char keyOfVal(int val, bool uc = false) const;
+    int valOfGlyph(char g) const;
+
+    // Block operations
+    void getBlock(int x, int y, int bw, int bh, char* out, int outSize) const;
+    void writeBlock(int x, int y, const char* block, bool overlap = false);
+
+    // Formatting
+    int format(char* out, int outSize) const;
+
+    // Parse operators (public for shadow buffer updates)
+    void parse();
+
+private:
+    void operate();
+    void clean(const char* src, char* dst, int maxLen);
+};
+
+} // namespace orca

--- a/plugin/Source/engine/MidiStack.h
+++ b/plugin/Source/engine/MidiStack.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include "Types.h"
+#include "Transpose.h"
+
+namespace orca {
+
+class MidiStack {
+public:
+    NoteEntry notes[kMaxNotes];
+    int noteCount = 0;
+
+    void clear() {
+        // Remove nulled entries
+        int write = 0;
+        for (int i = 0; i < noteCount; i++) {
+            if (notes[i].active) {
+                if (write != i) notes[write] = notes[i];
+                write++;
+            }
+        }
+        noteCount = write;
+    }
+
+    void push(int channel, int octave, char note, int velocity, int length) {
+        NoteEntry item;
+        item.channel = channel;
+        item.octave = octave;
+        item.note = note;
+        item.velocity = velocity;
+        item.length = length;
+        item.isPlayed = false;
+        item.active = true;
+
+        // Retrigger: release duplicates with same channel+octave+note
+        for (int i = 0; i < noteCount; i++) {
+            if (!notes[i].active) continue;
+            if (notes[i].channel == channel && notes[i].octave == octave && notes[i].note == note) {
+                notes[i].active = false; // mark for release
+            }
+        }
+
+        if (noteCount < kMaxNotes) {
+            notes[noteCount++] = item;
+        }
+    }
+
+    // Process one frame: returns MIDI events via callback
+    // outEvents must have space for at least kMaxNotes * 2 events
+    int run(MidiEvent* outEvents, int maxEvents) {
+        int eventCount = 0;
+
+        for (int i = 0; i < noteCount; i++) {
+            if (!notes[i].active) {
+                // Generate note-off for retriggered notes
+                if (eventCount < maxEvents) {
+                    auto tr = transpose(notes[i].note, notes[i].octave);
+                    if (tr.valid && tr.id > 0) {
+                        auto& e = outEvents[eventCount++];
+                        e.type = MidiEvent::NoteOff;
+                        int ch = notes[i].channel;
+                        e.bytes[0] = static_cast<uint8_t>(0x80 + ch);
+                        e.bytes[1] = static_cast<uint8_t>(tr.id);
+                        e.bytes[2] = static_cast<uint8_t>((notes[i].velocity * 127) / 16);
+                        e.numBytes = 3;
+                    }
+                }
+                continue;
+            }
+
+            if (!notes[i].isPlayed) {
+                // Press: generate note-on
+                auto tr = transpose(notes[i].note, notes[i].octave);
+                if (tr.valid && tr.id > 0 && eventCount < maxEvents) {
+                    auto& e = outEvents[eventCount++];
+                    e.type = MidiEvent::NoteOn;
+                    int ch = notes[i].channel;
+                    e.bytes[0] = static_cast<uint8_t>(0x90 + ch);
+                    e.bytes[1] = static_cast<uint8_t>(tr.id);
+                    e.bytes[2] = static_cast<uint8_t>((notes[i].velocity * 127) / 16);
+                    e.numBytes = 3;
+                }
+                notes[i].isPlayed = true;
+            }
+
+            if (notes[i].length < 1) {
+                // Release
+                auto tr = transpose(notes[i].note, notes[i].octave);
+                if (tr.valid && tr.id > 0 && eventCount < maxEvents) {
+                    auto& e = outEvents[eventCount++];
+                    e.type = MidiEvent::NoteOff;
+                    int ch = notes[i].channel;
+                    e.bytes[0] = static_cast<uint8_t>(0x80 + ch);
+                    e.bytes[1] = static_cast<uint8_t>(tr.id);
+                    e.bytes[2] = static_cast<uint8_t>((notes[i].velocity * 127) / 16);
+                    e.numBytes = 3;
+                }
+                notes[i].active = false;
+            } else {
+                notes[i].length--;
+            }
+        }
+
+        return eventCount;
+    }
+
+    void silence(MidiEvent* outEvents, int maxEvents, int& eventCount) {
+        for (int i = 0; i < noteCount; i++) {
+            if (!notes[i].active) continue;
+            auto tr = transpose(notes[i].note, notes[i].octave);
+            if (tr.valid && tr.id > 0 && eventCount < maxEvents) {
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::NoteOff;
+                int ch = notes[i].channel;
+                e.bytes[0] = static_cast<uint8_t>(0x80 + ch);
+                e.bytes[1] = static_cast<uint8_t>(tr.id);
+                e.bytes[2] = 0;
+                e.numBytes = 3;
+            }
+            notes[i].active = false;
+        }
+        noteCount = 0;
+    }
+
+    int length() const {
+        int count = 0;
+        for (int i = 0; i < noteCount; i++)
+            if (notes[i].active) count++;
+        return count;
+    }
+};
+
+} // namespace orca

--- a/plugin/Source/engine/MonoStack.h
+++ b/plugin/Source/engine/MonoStack.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include "Types.h"
+#include "Transpose.h"
+
+namespace orca {
+
+class MonoStack {
+public:
+    NoteEntry channels[kMaxMonoChannels];
+
+    // Pending note-offs from push() replacing an active note
+    struct PendingRelease {
+        int channel;
+        char note;
+        int octave;
+        int velocity;
+        bool active;
+    };
+    PendingRelease pendingReleases[kMaxMonoChannels];
+    int pendingCount = 0;
+
+    MonoStack() {
+        for (int i = 0; i < kMaxMonoChannels; i++)
+            channels[i].active = false;
+        pendingCount = 0;
+    }
+
+    void clear() {
+        // Mono stack persists across frames (no clear per frame)
+    }
+
+    void push(int channel, int octave, char note, int velocity, int length) {
+        if (channel < 0 || channel >= kMaxMonoChannels) return;
+
+        // Queue note-off for the previous note on this channel
+        if (channels[channel].active && channels[channel].isPlayed && pendingCount < kMaxMonoChannels) {
+            auto& pr = pendingReleases[pendingCount++];
+            pr.channel = channel;
+            pr.note = channels[channel].note;
+            pr.octave = channels[channel].octave;
+            pr.velocity = channels[channel].velocity;
+            pr.active = true;
+        }
+
+        channels[channel].channel = channel;
+        channels[channel].octave = octave;
+        channels[channel].note = note;
+        channels[channel].velocity = velocity;
+        channels[channel].length = length;
+        channels[channel].isPlayed = false;
+        channels[channel].active = true;
+    }
+
+    int run(MidiEvent* outEvents, int maxEvents) {
+        int eventCount = 0;
+
+        // Emit pending note-offs from replaced notes first
+        for (int i = 0; i < pendingCount; i++) {
+            if (!pendingReleases[i].active) continue;
+            auto tr = transpose(pendingReleases[i].note, pendingReleases[i].octave);
+            if (tr.valid && tr.id > 0 && eventCount < maxEvents) {
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::NoteOff;
+                e.bytes[0] = static_cast<uint8_t>(0x80 + pendingReleases[i].channel);
+                e.bytes[1] = static_cast<uint8_t>(tr.id);
+                e.bytes[2] = static_cast<uint8_t>((pendingReleases[i].velocity * 127) / 16);
+                e.numBytes = 3;
+            }
+        }
+        pendingCount = 0;
+
+        for (int ch = 0; ch < kMaxMonoChannels; ch++) {
+            if (!channels[ch].active) continue;
+
+            if (channels[ch].length < 1) {
+                // Release
+                auto tr = transpose(channels[ch].note, channels[ch].octave);
+                if (tr.valid && tr.id > 0 && eventCount < maxEvents) {
+                    auto& e = outEvents[eventCount++];
+                    e.type = MidiEvent::NoteOff;
+                    e.bytes[0] = static_cast<uint8_t>(0x80 + ch);
+                    e.bytes[1] = static_cast<uint8_t>(tr.id);
+                    e.bytes[2] = static_cast<uint8_t>((channels[ch].velocity * 127) / 16);
+                    e.numBytes = 3;
+                }
+                channels[ch].active = false;
+                continue;
+            }
+
+            if (!channels[ch].isPlayed) {
+                // Press
+                auto tr = transpose(channels[ch].note, channels[ch].octave);
+                if (tr.valid && tr.id > 0 && eventCount < maxEvents) {
+                    auto& e = outEvents[eventCount++];
+                    e.type = MidiEvent::NoteOn;
+                    e.bytes[0] = static_cast<uint8_t>(0x90 + ch);
+                    e.bytes[1] = static_cast<uint8_t>(tr.id);
+                    e.bytes[2] = static_cast<uint8_t>((channels[ch].velocity * 127) / 16);
+                    e.numBytes = 3;
+                }
+                channels[ch].isPlayed = true;
+            }
+
+            channels[ch].length--;
+        }
+
+        return eventCount;
+    }
+
+    void silence(MidiEvent* outEvents, int maxEvents, int& eventCount) {
+        for (int ch = 0; ch < kMaxMonoChannels; ch++) {
+            if (!channels[ch].active) {
+                continue;
+            }
+            auto tr = transpose(channels[ch].note, channels[ch].octave);
+            if (tr.valid && tr.id > 0 && eventCount < maxEvents) {
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::NoteOff;
+                e.bytes[0] = static_cast<uint8_t>(0x80 + ch);
+                e.bytes[1] = static_cast<uint8_t>(tr.id);
+                e.bytes[2] = 0;
+                e.numBytes = 3;
+            }
+            channels[ch].active = false;
+        }
+    }
+
+    int length() const {
+        int count = 0;
+        for (int i = 0; i < kMaxMonoChannels; i++)
+            if (channels[i].active) count++;
+        return count;
+    }
+};
+
+} // namespace orca

--- a/plugin/Source/engine/Operator.cpp
+++ b/plugin/Source/engine/Operator.cpp
@@ -1,0 +1,854 @@
+#include "Operator.h"
+#include "Grid.h"
+#include "EngineIO.h"
+#include <cmath>
+#include <cstdlib>
+
+namespace orca {
+
+// ── OperatorInstance base methods ──
+
+void OperatorInstance::init(OpType t, int px, int py, char g, bool isPassive) {
+    type = t;
+    x = px;
+    y = py;
+    glyph = g;
+    passive = isPassive;
+    draw = isPassive;
+    portCount = 0;
+    outputPortIdx = -1;
+}
+
+void OperatorInstance::addPort(int idx, int rx, int ry, bool output, bool bang,
+                               bool reader, bool sensitive,
+                               char defaultVal, int clampMin, int clampMax) {
+    if (idx >= kMaxPorts) return;
+    auto& p = ports[idx];
+    p.x = rx;
+    p.y = ry;
+    p.output = output;
+    p.bang = bang;
+    p.reader = reader;
+    p.sensitive = sensitive;
+    p.defaultVal = defaultVal;
+    p.clampMin = clampMin;
+    p.clampMax = clampMax;
+    p.active = true;
+    if (idx >= portCount) portCount = idx + 1;
+    if (output && outputPortIdx < 0) outputPortIdx = idx;
+}
+
+char OperatorInstance::listen(Grid& grid, const Port& port, bool toValue) const {
+    char g = grid.glyphAt(x + port.x, y + port.y);
+    char gl = (g == '.' || g == '*') && port.defaultVal ? port.defaultVal : g;
+    if (toValue) {
+        int val = valueOf(gl);
+        return static_cast<char>(clamp(val, port.clampMin, port.clampMax));
+    }
+    return gl;
+}
+
+char OperatorInstance::listenAt(Grid& grid, int rx, int ry, bool toValue) const {
+    Port p;
+    p.x = rx; p.y = ry;
+    p.defaultVal = 0; p.clampMin = 0; p.clampMax = 36;
+    p.active = true;
+    return listen(grid, p, toValue);
+}
+
+void OperatorInstance::output(Grid& grid, char g, const Port& port) const {
+    if (g == 0) return;
+    if (shouldUpperCase(grid) && port.sensitive) {
+        g = toUpper(g);
+    }
+    grid.write(x + port.x, y + port.y, g);
+}
+
+void OperatorInstance::bang(Grid& grid, bool b) const {
+    if (outputPortIdx < 0) return;
+    auto& p = ports[outputPortIdx];
+    grid.write(x + p.x, y + p.y, b ? '*' : '.');
+    grid.lock(x + p.x, y + p.y);
+}
+
+void OperatorInstance::move(Grid& grid, int dx, int dy) {
+    int nx = x + dx, ny = y + dy;
+    if (!grid.inBounds(nx, ny) || grid.glyphAt(nx, ny) != '.') {
+        explode(grid);
+        return;
+    }
+    erase(grid);
+    x += dx;
+    y += dy;
+    grid.write(x, y, glyph);
+    lockSelf(grid);
+}
+
+bool OperatorInstance::hasNeighbor(Grid& grid, char g) const {
+    if (grid.glyphAt(x + 1, y) == g) return true;
+    if (grid.glyphAt(x - 1, y) == g) return true;
+    if (grid.glyphAt(x, y + 1) == g) return true;
+    if (grid.glyphAt(x, y - 1) == g) return true;
+    return false;
+}
+
+void OperatorInstance::erase(Grid& grid) {
+    grid.write(x, y, '.');
+}
+
+void OperatorInstance::explode(Grid& grid) {
+    grid.write(x, y, '*');
+}
+
+void OperatorInstance::lockSelf(Grid& grid) {
+    grid.lock(x, y);
+}
+
+bool OperatorInstance::shouldUpperCase(Grid& grid) const {
+    if (outputPortIdx < 0 || !ports[outputPortIdx].sensitive) return false;
+    char val = grid.glyphAt(x + 1, y);
+    if (!isLetter(val)) return false;
+    return isUpper(val);
+}
+
+// ── Main run ──
+
+void OperatorInstance::run(Grid& grid, EngineIO& io, bool force) {
+    char result = 0;
+    bool hasResult = false;
+
+    operation(grid, io, force, result, hasResult);
+
+    // Lock all non-bang ports
+    for (int i = 0; i < portCount; i++) {
+        if (!ports[i].active || ports[i].bang) continue;
+        grid.lock(x + ports[i].x, y + ports[i].y);
+    }
+
+    if (outputPortIdx >= 0 && hasResult) {
+        auto& outPort = ports[outputPortIdx];
+        if (outPort.bang) {
+            bang(grid, result != 0);
+        } else {
+            output(grid, result, outPort);
+        }
+    }
+}
+
+// ── Port index constants ──
+// We use fixed indices for named ports to avoid string lookups.
+enum PortIdx {
+    PA = 0,   // 'a' input
+    PB = 1,   // 'b' input
+    POut = 2, // output
+    PRate = 0,
+    PMod = 1,
+    PStep = 0,
+    PMax = 1,
+    PX = 0,
+    PY = 1,
+    PLen = 2,
+    PVal = 3,
+    PKey = 0,
+    PWrite = 0,
+    PRead = 1,
+    PChannel = 0,
+    POctave = 1,
+    PNote = 2,
+    PVelocity = 3,
+    PLength = 4,
+    PKnob = 1,
+    PValue = 2,
+    PLsb = 1,
+    PMsb = 2,
+    PPath = 0,
+};
+
+// ── Operator-specific logic ──
+
+void OperatorInstance::operation(Grid& grid, EngineIO& io, bool force,
+                                 char& result, bool& hasResult) {
+    switch (type) {
+
+    case OpType::A: { // add
+        int a = static_cast<int>(listen(grid, ports[PA], true));
+        int b = static_cast<int>(listen(grid, ports[PB], true));
+        result = keyOf(a + b);
+        hasResult = true;
+        break;
+    }
+
+    case OpType::B: { // subtract
+        int a = static_cast<int>(listen(grid, ports[PA], true));
+        int b = static_cast<int>(listen(grid, ports[PB], true));
+        result = keyOf(std::abs(b - a));
+        hasResult = true;
+        break;
+    }
+
+    case OpType::C: { // clock
+        int rate = static_cast<int>(listen(grid, ports[PRate], true));
+        int mod = static_cast<int>(listen(grid, ports[PMod], true));
+        if (rate == 0) rate = 1;
+        int val = mod > 0 ? (grid.f / rate) % mod : 0;
+        result = keyOf(val);
+        hasResult = true;
+        break;
+    }
+
+    case OpType::D: { // delay
+        int rate = static_cast<int>(listen(grid, ports[PRate], true));
+        int mod = static_cast<int>(listen(grid, ports[PMod], true));
+        if (rate == 0) rate = 1;
+        if (mod == 0) mod = 1;
+        int res = grid.f % (mod * rate);
+        result = (res == 0 || mod == 1) ? 1 : 0;
+        hasResult = true;
+        break;
+    }
+
+    case OpType::E: { // east
+        move(grid, 1, 0);
+        passive = false;
+        break;
+    }
+
+    case OpType::F: { // if
+        char a = listen(grid, ports[PA], false);
+        char b = listen(grid, ports[PB], false);
+        result = (a == b) ? 1 : 0;
+        hasResult = true;
+        break;
+    }
+
+    case OpType::G: { // generator
+        int len = static_cast<int>(listen(grid, ports[PLen], true));
+        int gx = static_cast<int>(listen(grid, ports[PX], true));
+        int gy = static_cast<int>(listen(grid, ports[PY], true)) + 1;
+        for (int offset = 0; offset < len; offset++) {
+            int inIdx = 4 + offset * 2;
+            int outIdx = 4 + offset * 2 + 1;
+            if (inIdx >= kMaxPorts || outIdx >= kMaxPorts) break;
+
+            addPort(inIdx, offset + 1, 0, false, false, false, false, 0, 0, 36);
+            addPort(outIdx, gx + offset, gy, true, false, false, false, 0, 0, 36);
+
+            char res = listen(grid, ports[inIdx], false);
+            output(grid, res, ports[outIdx]);
+        }
+        break;
+    }
+
+    case OpType::H: { // halt
+        grid.lock(x + ports[POut].x, y + ports[POut].y);
+        result = listen(grid, ports[POut], false);
+        hasResult = false; // halt reads but doesn't write
+        break;
+    }
+
+    case OpType::I: { // increment
+        int step = static_cast<int>(listen(grid, ports[PStep], true));
+        int mod = static_cast<int>(listen(grid, ports[PMod], true));
+        int val = static_cast<int>(listen(grid, ports[POut], true));
+        if (mod > 0) {
+            result = keyOf((val + step) % mod);
+        } else {
+            result = '0';
+        }
+        hasResult = true;
+        break;
+    }
+
+    case OpType::J: { // jumper
+        char val = listenAt(grid, 0, -1, false);
+        if (val != 'J') {
+            int i = 0;
+            while (grid.inBounds(x, y + i)) {
+                char next = listenAt(grid, 0, ++i, false);
+                if (next != glyph) break;
+            }
+            // Add input and output ports dynamically
+            int inIdx = 0, outIdx = 1;
+            addPort(inIdx, 0, -1, false, false, false, false, 0, 0, 36);
+            addPort(outIdx, 0, i, true, false, false, false, 0, 0, 36);
+            outputPortIdx = outIdx;
+            result = val;
+            hasResult = true;
+        }
+        break;
+    }
+
+    case OpType::K: { // konkat
+        int len = static_cast<int>(listen(grid, ports[0], true));
+        for (int offset = 0; offset < len; offset++) {
+            char key = grid.glyphAt(x + offset + 1, y);
+            grid.lock(x + offset + 1, y);
+            if (key == '.') continue;
+
+            int inIdx = 2 + offset * 2;
+            int outIdx = 2 + offset * 2 + 1;
+            if (inIdx >= kMaxPorts || outIdx >= kMaxPorts) break;
+
+            addPort(inIdx, offset + 1, 0, false, false, false, false, 0, 0, 36);
+            addPort(outIdx, offset + 1, 1, true, false, false, false, 0, 0, 36);
+
+            char res = grid.valueIn(key);
+            output(grid, res, ports[outIdx]);
+        }
+        break;
+    }
+
+    case OpType::L: { // lesser
+        int a = static_cast<int>(listen(grid, ports[PA], true));
+        int b = static_cast<int>(listen(grid, ports[PB], true));
+        result = keyOf(a > b ? b : a);
+        hasResult = true;
+        break;
+    }
+
+    case OpType::M: { // multiply
+        int a = static_cast<int>(listen(grid, ports[PA], true));
+        int b = static_cast<int>(listen(grid, ports[PB], true));
+        result = keyOf(a * b);
+        hasResult = true;
+        break;
+    }
+
+    case OpType::N: { // north
+        move(grid, 0, -1);
+        passive = false;
+        break;
+    }
+
+    case OpType::O: { // read
+        int ox = static_cast<int>(listen(grid, ports[PX], true));
+        int oy = static_cast<int>(listen(grid, ports[PY], true));
+        int readIdx = 3;
+        addPort(readIdx, ox + 1, oy, false, false, false, false, 0, 0, 36);
+        result = listen(grid, ports[readIdx], false);
+        hasResult = true;
+        break;
+    }
+
+    case OpType::P: { // push
+        int len = static_cast<int>(listen(grid, ports[1], true));
+        int key = static_cast<int>(listen(grid, ports[0], true));
+        for (int offset = 0; offset < len; offset++) {
+            grid.lock(x + offset, y + 1);
+        }
+        int outIdx = 3;
+        addPort(outIdx, (len > 0) ? key % len : 0, 1, true, false, false, false, 0, 0, 36);
+        outputPortIdx = outIdx;
+        result = listen(grid, ports[2], false);
+        hasResult = true;
+        break;
+    }
+
+    case OpType::Q: { // query
+        int len = static_cast<int>(listen(grid, ports[PLen], true));
+        int qx = static_cast<int>(listen(grid, ports[PX], true));
+        int qy = static_cast<int>(listen(grid, ports[PY], true));
+        for (int offset = 0; offset < len; offset++) {
+            int inIdx = 4 + offset * 2;
+            int outIdx = 4 + offset * 2 + 1;
+            if (inIdx >= kMaxPorts || outIdx >= kMaxPorts) break;
+
+            addPort(inIdx, qx + offset + 1, qy, false, false, false, false, 0, 0, 36);
+            addPort(outIdx, offset - len + 1, 1, true, false, false, false, 0, 0, 36);
+
+            char res = listen(grid, ports[inIdx], false);
+            output(grid, res, ports[outIdx]);
+        }
+        break;
+    }
+
+    case OpType::R: { // random
+        int a = static_cast<int>(listen(grid, ports[PA], true));
+        int b = static_cast<int>(listen(grid, ports[PB], true));
+        if (a == b) {
+            result = keyOf(a);
+        } else if (a > b) {
+            result = keyOf(std::rand() % (a - b + 1) + b);
+        } else {
+            result = keyOf(std::rand() % (b - a + 1) + a);
+        }
+        hasResult = true;
+        break;
+    }
+
+    case OpType::S: { // south
+        move(grid, 0, 1);
+        passive = false;
+        break;
+    }
+
+    case OpType::T: { // track
+        int len = static_cast<int>(listen(grid, ports[1], true));
+        int key = static_cast<int>(listen(grid, ports[0], true));
+        for (int offset = 0; offset < len; offset++) {
+            grid.lock(x + offset + 1, y);
+        }
+        int valIdx = 3;
+        addPort(valIdx, (len > 0) ? (key % len) + 1 : 1, 0, false, false, false, false, 0, 0, 36);
+        result = listen(grid, ports[valIdx], false);
+        hasResult = true;
+        break;
+    }
+
+    case OpType::U: { // uclid
+        int step = static_cast<int>(listen(grid, ports[PStep], true));
+        int max = static_cast<int>(listen(grid, ports[PMax], true));
+        if (max == 0) max = 1;
+        int bucket = (step * (grid.f + max - 1)) % max + step;
+        result = (bucket >= max) ? 1 : 0;
+        hasResult = true;
+        break;
+    }
+
+    case OpType::V: { // variable
+        char w = listen(grid, ports[PWrite], false);
+        char r = listen(grid, ports[PRead], false);
+        if (w == '.' && r != '.') {
+            int outIdx = 2;
+            addPort(outIdx, 0, 1, true, false, false, false, 0, 0, 36);
+            outputPortIdx = outIdx;
+            result = grid.valueIn(r);
+            hasResult = true;
+        }
+        if (w != '.') {
+            uint8_t idx = static_cast<uint8_t>(w);
+            if (idx < 128) grid.variables[idx] = r;
+        }
+        break;
+    }
+
+    case OpType::W: { // west
+        move(grid, -1, 0);
+        passive = false;
+        break;
+    }
+
+    case OpType::X: { // write
+        int wx = static_cast<int>(listen(grid, ports[0], true));
+        int wy = static_cast<int>(listen(grid, ports[1], true)) + 1;
+        result = listen(grid, ports[2], false);  // read val before creating dynamic output
+        int outIdx = 3;
+        addPort(outIdx, wx, wy, true, false, false, false, 0, 0, 36);
+        outputPortIdx = outIdx;
+        hasResult = true;
+        break;
+    }
+
+    case OpType::Y: { // jymper
+        char val = listenAt(grid, -1, 0, false);
+        if (val != 'Y') {
+            int i = 0;
+            while (grid.inBounds(x + i, y)) {
+                char next = listenAt(grid, ++i, 0, false);
+                if (next != glyph) break;
+            }
+            int inIdx = 0, outIdx = 1;
+            addPort(inIdx, -1, 0, false, false, false, false, 0, 0, 36);
+            addPort(outIdx, i, 0, true, false, false, false, 0, 0, 36);
+            outputPortIdx = outIdx;
+            result = val;
+            hasResult = true;
+        }
+        break;
+    }
+
+    case OpType::Z: { // lerp
+        int rate = static_cast<int>(listen(grid, ports[PRate], true));
+        int target = static_cast<int>(listen(grid, ports[PMod], true)); // target is at port index 1
+        int val = static_cast<int>(listen(grid, ports[POut], true));
+        int mod;
+        if (val <= target - rate) mod = rate;
+        else if (val >= target + rate) mod = -rate;
+        else mod = target - val;
+        result = keyOf(val + mod);
+        hasResult = true;
+        break;
+    }
+
+    case OpType::Bang: { // *
+        draw = false;
+        erase(grid);
+        break;
+    }
+
+    case OpType::Comment: { // #
+        for (int cx = x + 1; cx <= grid.w; cx++) {
+            grid.lock(cx, y);
+            if (grid.glyphAt(cx, y) == '#') break;
+        }
+        grid.lock(x, y);
+        break;
+    }
+
+    case OpType::Midi: { // :
+        if (!hasNeighbor(grid, '*') && !force) break;
+        char chGlyph = listen(grid, ports[PChannel], false);
+        char octGlyph = listen(grid, ports[POctave], false);
+        char noteGlyph = listen(grid, ports[PNote], false);
+        if (chGlyph == '.' || octGlyph == '.' || noteGlyph == '.') break;
+        // Note must be a letter, not a digit
+        if (isDigitChar(noteGlyph)) break;
+
+        int channel = static_cast<int>(listen(grid, ports[PChannel], true));
+        if (channel > 15) break;
+        int octave = static_cast<int>(listen(grid, ports[POctave], true));
+        char note = noteGlyph;
+        int velocity = static_cast<int>(listen(grid, ports[PVelocity], true));
+        int length = static_cast<int>(listen(grid, ports[PLength], true));
+
+        io.midi.push(channel, octave, note, velocity, length);
+        draw = false;
+        break;
+    }
+
+    case OpType::CC: { // !
+        if (!hasNeighbor(grid, '*') && !force) break;
+        char chGlyph = listen(grid, ports[PChannel], false);
+        char knobGlyph = listen(grid, ports[PKnob], false);
+        if (chGlyph == '.' || knobGlyph == '.') break;
+
+        int channel = static_cast<int>(listen(grid, ports[PChannel], true));
+        if (channel > 15) break;
+        int knob = static_cast<int>(listen(grid, ports[PKnob], true));
+        int rawValue = static_cast<int>(listen(grid, ports[PValue], true));
+        int value = (int)std::ceil((127.0 * rawValue) / 35.0);
+
+        io.cc.pushCC(channel, knob, value);
+        draw = false;
+        break;
+    }
+
+    case OpType::PitchBend: { // ?
+        if (!hasNeighbor(grid, '*') && !force) break;
+        char chGlyph = listen(grid, ports[PChannel], false);
+        char lsbGlyph = listen(grid, ports[PLsb], false);
+        if (chGlyph == '.' || lsbGlyph == '.') break;
+
+        int channel = static_cast<int>(listen(grid, ports[PChannel], true));
+        int rawLsb = static_cast<int>(listen(grid, ports[PLsb], true));
+        int lsb = (int)std::ceil((127.0 * rawLsb) / 35.0);
+        int rawMsb = static_cast<int>(listen(grid, ports[PMsb], true));
+        int msb = (int)std::ceil((127.0 * rawMsb) / 35.0);
+
+        io.cc.pushPB(channel, lsb, msb);
+        draw = false;
+        break;
+    }
+
+    case OpType::Mono: { // %
+        if (!hasNeighbor(grid, '*') && !force) break;
+        char chGlyph = listen(grid, ports[PChannel], false);
+        char octGlyph = listen(grid, ports[POctave], false);
+        char noteGlyph = listen(grid, ports[PNote], false);
+        if (chGlyph == '.' || octGlyph == '.' || noteGlyph == '.') break;
+        if (isDigitChar(noteGlyph)) break;
+
+        int channel = static_cast<int>(listen(grid, ports[PChannel], true));
+        if (channel > 15) break;
+        int octave = static_cast<int>(listen(grid, ports[POctave], true));
+        char note = noteGlyph;
+        int velocity = static_cast<int>(listen(grid, ports[PVelocity], true));
+        int length = static_cast<int>(listen(grid, ports[PLength], true));
+
+        io.mono.push(channel, octave, note, velocity, length);
+        draw = false;
+        break;
+    }
+
+    case OpType::Osc: // = (no-op in plugin)
+    case OpType::Udp: // ; (no-op in plugin)
+    {
+        // Lock eastward glyphs until '.'
+        for (int lx = 1; lx <= 36; lx++) {
+            char g = grid.glyphAt(x + lx, y);
+            grid.lock(x + lx, y);
+            if (g == '.') break;
+        }
+        break;
+    }
+
+    case OpType::Self: { // $
+        // Lock eastward glyphs until '.'
+        for (int lx = 1; lx <= 36; lx++) {
+            char g = grid.glyphAt(x + lx, y);
+            grid.lock(x + lx, y);
+            if (g == '.') break;
+        }
+        // No-op in plugin context (would need commander)
+        break;
+    }
+
+    case OpType::Null:
+        break;
+
+    default:
+        break;
+    }
+}
+
+// ── Factory ──
+
+bool isOperatorGlyph(char g) {
+    char lower = toLower(g);
+    if (lower >= 'a' && lower <= 'z') return true;
+    if (g >= '0' && g <= '9') return true;
+    switch (g) {
+        case '*': case '#': case ':': case '!':
+        case '?': case '%': case '=': case ';':
+        case '$':
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool createOperator(OperatorInstance& op, char glyph, int x, int y, bool isPassive) {
+    char lower = toLower(glyph);
+    op.portCount = 0;
+    op.outputPortIdx = -1;
+
+    // Map glyph to OpType and set up ports
+    switch (lower) {
+    case 'a':
+        op.init(OpType::A, x, y, glyph, isPassive);
+        op.addPort(PA, -1, 0);              // a
+        op.addPort(PB, 1, 0);               // b
+        op.addPort(POut, 0, 1, true, false, false, true); // output (sensitive)
+        return true;
+
+    case 'b':
+        op.init(OpType::B, x, y, glyph, isPassive);
+        op.addPort(PA, -1, 0);
+        op.addPort(PB, 1, 0);
+        op.addPort(POut, 0, 1, true, false, false, true);
+        return true;
+
+    case 'c':
+        op.init(OpType::C, x, y, glyph, isPassive);
+        op.addPort(PRate, -1, 0, false, false, false, false, 0, 1, 36);
+        op.addPort(PMod, 1, 0);
+        op.addPort(POut, 0, 1, true, false, false, true);
+        return true;
+
+    case 'd':
+        op.init(OpType::D, x, y, glyph, isPassive);
+        op.addPort(PRate, -1, 0, false, false, false, false, 0, 1, 36);
+        op.addPort(PMod, 1, 0, false, false, false, false, 0, 1, 36);
+        op.addPort(POut, 0, 1, true, true); // bang output
+        return true;
+
+    case 'e':
+        op.init(OpType::E, x, y, glyph, isPassive);
+        op.draw = false;
+        return true;
+
+    case 'f':
+        op.init(OpType::F, x, y, glyph, isPassive);
+        op.addPort(PA, -1, 0);
+        op.addPort(PB, 1, 0);
+        op.addPort(POut, 0, 1, true, true); // bang output
+        return true;
+
+    case 'g':
+        op.init(OpType::G, x, y, glyph, isPassive);
+        op.addPort(PX, -3, 0);
+        op.addPort(PY, -2, 0);
+        op.addPort(PLen, -1, 0, false, false, false, false, 0, 1, 36);
+        return true;
+
+    case 'h':
+        op.init(OpType::H, x, y, glyph, isPassive);
+        op.addPort(POut, 0, 1, true, false, true); // reader output
+        return true;
+
+    case 'i':
+        op.init(OpType::I, x, y, glyph, isPassive);
+        op.addPort(PStep, -1, 0);
+        op.addPort(PMod, 1, 0);
+        op.addPort(POut, 0, 1, true, false, true, true); // reader, sensitive
+        return true;
+
+    case 'j':
+        op.init(OpType::J, x, y, glyph, isPassive);
+        // Ports added dynamically in operation
+        return true;
+
+    case 'k':
+        op.init(OpType::K, x, y, glyph, isPassive);
+        op.addPort(0, -1, 0, false, false, false, false, 0, 1, 36); // len
+        return true;
+
+    case 'l':
+        op.init(OpType::L, x, y, glyph, isPassive);
+        op.addPort(PA, -1, 0);
+        op.addPort(PB, 1, 0);
+        op.addPort(POut, 0, 1, true, false, false, true);
+        return true;
+
+    case 'm':
+        op.init(OpType::M, x, y, glyph, isPassive);
+        op.addPort(PA, -1, 0);
+        op.addPort(PB, 1, 0);
+        op.addPort(POut, 0, 1, true, false, false, true);
+        return true;
+
+    case 'n':
+        op.init(OpType::N, x, y, glyph, isPassive);
+        op.draw = false;
+        return true;
+
+    case 'o':
+        op.init(OpType::O, x, y, glyph, isPassive);
+        op.addPort(PX, -2, 0);
+        op.addPort(PY, -1, 0);
+        op.addPort(POut, 0, 1, true);
+        return true;
+
+    case 'p':
+        op.init(OpType::P, x, y, glyph, isPassive);
+        op.addPort(0, -2, 0);                                        // key
+        op.addPort(1, -1, 0, false, false, false, false, 0, 1, 36);  // len
+        op.addPort(2, 1, 0);                                          // val
+        // output port added dynamically in operation at index 3
+        return true;
+
+    case 'q':
+        op.init(OpType::Q, x, y, glyph, isPassive);
+        op.addPort(PX, -3, 0);
+        op.addPort(PY, -2, 0);
+        op.addPort(PLen, -1, 0, false, false, false, false, 0, 1, 36);
+        return true;
+
+    case 'r':
+        op.init(OpType::R, x, y, glyph, isPassive);
+        op.addPort(PA, -1, 0);
+        op.addPort(PB, 1, 0);
+        op.addPort(POut, 0, 1, true, false, false, true);
+        return true;
+
+    case 's':
+        op.init(OpType::S, x, y, glyph, isPassive);
+        op.draw = false;
+        return true;
+
+    case 't':
+        op.init(OpType::T, x, y, glyph, isPassive);
+        op.addPort(0, -2, 0);                                        // key
+        op.addPort(1, -1, 0, false, false, false, false, 0, 1, 36);  // len
+        op.addPort(2, 0, 1, true);                                    // output
+        return true;
+
+    case 'u':
+        op.init(OpType::U, x, y, glyph, isPassive);
+        op.addPort(PStep, -1, 0, false, false, false, false, 0, 0, 36);
+        op.addPort(PMax, 1, 0, false, false, false, false, 0, 1, 36);
+        op.addPort(POut, 0, 1, true, true); // bang
+        return true;
+
+    case 'v':
+        op.init(OpType::V, x, y, glyph, isPassive);
+        op.addPort(PWrite, -1, 0);
+        op.addPort(PRead, 1, 0);
+        // Output port added dynamically
+        return true;
+
+    case 'w':
+        op.init(OpType::W, x, y, glyph, isPassive);
+        op.draw = false;
+        return true;
+
+    case 'x':
+        op.init(OpType::X, x, y, glyph, isPassive);
+        op.addPort(0, -2, 0);   // x offset
+        op.addPort(1, -1, 0);   // y offset
+        op.addPort(2, 1, 0);    // val
+        // output port added dynamically in operation at index 3
+        return true;
+
+    case 'y':
+        op.init(OpType::Y, x, y, glyph, isPassive);
+        // Ports added dynamically
+        return true;
+
+    case 'z':
+        op.init(OpType::Z, x, y, glyph, isPassive);
+        op.addPort(PRate, -1, 0);
+        op.addPort(PMod, 1, 0);  // target
+        op.addPort(POut, 0, 1, true, false, true, true); // reader, sensitive
+        return true;
+    default:
+        break;
+    }
+
+    // Special characters
+    switch (glyph) {
+    case '*':
+        op.init(OpType::Bang, x, y, '*', true);
+        op.draw = false;
+        return true;
+
+    case '#':
+        op.init(OpType::Comment, x, y, '#', true);
+        op.draw = false;
+        return true;
+
+    case ':':
+        op.init(OpType::Midi, x, y, ':', true);
+        op.addPort(PChannel, 1, 0);
+        op.addPort(POctave, 2, 0, false, false, false, false, 0, 0, 8);
+        op.addPort(PNote, 3, 0);
+        op.addPort(PVelocity, 4, 0, false, false, false, false, 'f', 0, 16);
+        op.addPort(PLength, 5, 0, false, false, false, false, '1', 0, 32);
+        return true;
+
+    case '!':
+        op.init(OpType::CC, x, y, '!', true);
+        op.addPort(PChannel, 1, 0);
+        op.addPort(PKnob, 2, 0, false, false, false, false, 0, 0, 36);
+        op.addPort(PValue, 3, 0, false, false, false, false, 0, 0, 36);
+        return true;
+
+    case '?':
+        op.init(OpType::PitchBend, x, y, '?', true);
+        op.addPort(PChannel, 1, 0, false, false, false, false, 0, 0, 15);
+        op.addPort(PLsb, 2, 0, false, false, false, false, 0, 0, 36);
+        op.addPort(PMsb, 3, 0, false, false, false, false, 0, 0, 36);
+        return true;
+
+    case '%':
+        op.init(OpType::Mono, x, y, '%', true);
+        op.addPort(PChannel, 1, 0);
+        op.addPort(POctave, 2, 0, false, false, false, false, 0, 0, 8);
+        op.addPort(PNote, 3, 0);
+        op.addPort(PVelocity, 4, 0, false, false, false, false, 'f', 0, 16);
+        op.addPort(PLength, 5, 0, false, false, false, false, '1', 0, 32);
+        return true;
+
+    case '=':
+        op.init(OpType::Osc, x, y, '=', true);
+        return true;
+
+    case ';':
+        op.init(OpType::Udp, x, y, ';', true);
+        return true;
+
+    case '$':
+        op.init(OpType::Self, x, y, '$', true);
+        return true;
+    }
+
+    // Digit characters (0-9)
+    if (glyph >= '0' && glyph <= '9') {
+        op.init(OpType::Null, x, y, '.', false);
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace orca

--- a/plugin/Source/engine/Operator.h
+++ b/plugin/Source/engine/Operator.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "Types.h"
+
+namespace orca {
+
+class Grid;
+class EngineIO;
+
+// Operator type enum — one per library entry
+enum class OpType : uint8_t {
+    A, B, C, D, E, F, G, H, I, J, K, L, M,
+    N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+    Bang, Comment,
+    Midi, CC, PitchBend, Mono, Osc, Udp, Self,
+    Null, // digit placeholders
+    Count
+};
+
+struct OperatorInstance {
+    OpType type;
+    int x, y;
+    bool passive;
+    bool draw;
+    char glyph;
+
+    Port ports[kMaxPorts];
+    int portCount;
+
+    // Named port indices for quick access
+    int outputPortIdx;
+
+    void init(OpType t, int px, int py, char g, bool isPassive);
+    void addPort(int idx, int rx, int ry, bool output = false, bool bang = false,
+                 bool reader = false, bool sensitive = false,
+                 char defaultVal = 0, int clampMin = 0, int clampMax = 36);
+
+    // Core operator methods
+    char listen(Grid& grid, const Port& port, bool toValue = false) const;
+    char listenAt(Grid& grid, int rx, int ry, bool toValue = false) const;
+    void output(Grid& grid, char g, const Port& port) const;
+    void bang(Grid& grid, bool b) const;
+    void move(Grid& grid, int dx, int dy);
+    bool hasNeighbor(Grid& grid, char g) const;
+    void erase(Grid& grid);
+    void explode(Grid& grid);
+    void lockSelf(Grid& grid);
+    bool shouldUpperCase(Grid& grid) const;
+
+    // Main execution
+    void run(Grid& grid, EngineIO& io, bool force = false);
+    void operation(Grid& grid, EngineIO& io, bool force, char& result, bool& hasResult);
+};
+
+// Factory: create operator from glyph
+bool createOperator(OperatorInstance& op, char glyph, int x, int y, bool isPassive);
+
+// Check if a glyph is a known operator
+bool isOperatorGlyph(char g);
+
+} // namespace orca

--- a/plugin/Source/engine/Transpose.h
+++ b/plugin/Source/engine/Transpose.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "Types.h"
+
+namespace orca {
+
+struct TransposeResult {
+    int id;      // MIDI note number 0-127
+    int value;   // index in note scale
+    char note;   // note name character
+    int octave;  // octave number
+    bool valid;
+};
+
+// Note name to scale index: C=0, c=1, D=2, d=3, E=4, F=5, f=6, G=7, g=8, A=9, a=10, B=11
+inline int noteIndex(char n) {
+    switch (n) {
+        case 'C': return 0;  case 'c': return 1;
+        case 'D': return 2;  case 'd': return 3;
+        case 'E': return 4;  case 'F': return 5;
+        case 'f': return 6;  case 'G': return 7;
+        case 'g': return 8;  case 'A': return 9;
+        case 'a': return 10; case 'B': return 11;
+        default:  return -1;
+    }
+}
+
+// Transpose table: maps input character to (noteName, octaveOffset)
+// Mirrors the JS transposeTable exactly
+inline bool getTransposeEntry(char c, char& noteName, int& octaveOffset) {
+    switch (c) {
+        // Standard chromatic mapping
+        case 'A': noteName = 'A'; octaveOffset = 0; return true;
+        // 'a' lowercase = sharp (a#)
+        // In Orca's table: lowercase = flat/sharp variants
+        case 'B': noteName = 'B'; octaveOffset = 0; return true;
+        case 'C': noteName = 'C'; octaveOffset = 0; return true;
+        case 'c': noteName = 'c'; octaveOffset = 0; return true;
+        case 'D': noteName = 'D'; octaveOffset = 0; return true;
+        case 'd': noteName = 'd'; octaveOffset = 0; return true;
+        case 'E': noteName = 'E'; octaveOffset = 0; return true;
+        case 'F': noteName = 'F'; octaveOffset = 0; return true;
+        case 'G': noteName = 'G'; octaveOffset = 0; return true;
+        case 'g': noteName = 'g'; octaveOffset = 0; return true;
+        case 'H': noteName = 'A'; octaveOffset = 0; return true;
+        case 'h': noteName = 'a'; octaveOffset = 0; return true;
+        case 'I': noteName = 'B'; octaveOffset = 0; return true;
+        case 'J': noteName = 'C'; octaveOffset = 1; return true;
+        case 'j': noteName = 'c'; octaveOffset = 1; return true;
+        case 'K': noteName = 'D'; octaveOffset = 1; return true;
+        case 'k': noteName = 'd'; octaveOffset = 1; return true;
+        case 'L': noteName = 'E'; octaveOffset = 1; return true;
+        case 'M': noteName = 'F'; octaveOffset = 1; return true;
+        case 'm': noteName = 'f'; octaveOffset = 1; return true;
+        case 'N': noteName = 'G'; octaveOffset = 1; return true;
+        case 'n': noteName = 'g'; octaveOffset = 1; return true;
+        case 'O': noteName = 'A'; octaveOffset = 1; return true;
+        case 'o': noteName = 'a'; octaveOffset = 1; return true;
+        case 'P': noteName = 'B'; octaveOffset = 1; return true;
+        case 'Q': noteName = 'C'; octaveOffset = 2; return true;
+        case 'q': noteName = 'c'; octaveOffset = 2; return true;
+        case 'R': noteName = 'D'; octaveOffset = 2; return true;
+        case 'r': noteName = 'd'; octaveOffset = 2; return true;
+        case 'S': noteName = 'E'; octaveOffset = 2; return true;
+        case 'T': noteName = 'F'; octaveOffset = 2; return true;
+        case 't': noteName = 'f'; octaveOffset = 2; return true;
+        case 'U': noteName = 'G'; octaveOffset = 2; return true;
+        case 'u': noteName = 'g'; octaveOffset = 2; return true;
+        case 'V': noteName = 'A'; octaveOffset = 2; return true;
+        case 'v': noteName = 'a'; octaveOffset = 2; return true;
+        case 'W': noteName = 'B'; octaveOffset = 2; return true;
+        case 'X': noteName = 'C'; octaveOffset = 3; return true;
+        case 'x': noteName = 'c'; octaveOffset = 3; return true;
+        case 'Y': noteName = 'D'; octaveOffset = 3; return true;
+        case 'y': noteName = 'd'; octaveOffset = 3; return true;
+        case 'Z': noteName = 'E'; octaveOffset = 3; return true;
+        // Catch letters that map to enharmonic equivalents
+        case 'a': noteName = 'a'; octaveOffset = 0; return true;
+        case 'e': noteName = 'F'; octaveOffset = 0; return true;
+        case 'f': noteName = 'f'; octaveOffset = 0; return true;
+        case 'l': noteName = 'F'; octaveOffset = 1; return true;
+        case 's': noteName = 'F'; octaveOffset = 2; return true;
+        case 'z': noteName = 'F'; octaveOffset = 3; return true;
+        case 'b': noteName = 'C'; octaveOffset = 1; return true;
+        case 'i': noteName = 'C'; octaveOffset = 1; return true;
+        case 'p': noteName = 'C'; octaveOffset = 2; return true;
+        case 'w': noteName = 'C'; octaveOffset = 3; return true;
+        default: return false;
+    }
+}
+
+inline TransposeResult transpose(char n, int o = 3) {
+    TransposeResult result = { 0, 0, '.', 0, false };
+    char noteName;
+    int octaveOffset;
+    if (!getTransposeEntry(n, noteName, octaveOffset)) return result;
+
+    int octave = clamp(o + octaveOffset, 0, 8);
+    int value = noteIndex(noteName);
+    if (value < 0) return result;
+
+    result.id = clamp((octave * 12) + value + 24, 0, 127);
+    result.value = value;
+    result.note = noteName;
+    result.octave = octave;
+    result.valid = true;
+    return result;
+}
+
+} // namespace orca

--- a/plugin/Source/engine/Types.h
+++ b/plugin/Source/engine/Types.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <cstdlib>
+#include <cmath>
+
+namespace orca {
+
+static constexpr int kMaxGridW = 256;
+static constexpr int kMaxGridH = 256;
+static constexpr int kMaxGridSize = kMaxGridW * kMaxGridH;
+static constexpr int kMaxNotes = 128;
+static constexpr int kMaxCCs = 64;
+static constexpr int kMaxMonoChannels = 16;
+static constexpr int kMaxEvents = 256;
+static constexpr int kMaxOperators = 4096;
+static constexpr int kMaxPorts = 40;
+static constexpr int kNumKeys = 36;
+
+static constexpr const char* kKeys = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+struct Port {
+    int x = 0;
+    int y = 0;
+    bool output = false;
+    bool bang = false;
+    bool reader = false;
+    bool sensitive = false;
+    char defaultVal = 0;
+    int clampMin = 0;
+    int clampMax = 36;
+    bool active = false;
+};
+
+struct MidiEvent {
+    enum Type : uint8_t { NoteOn, NoteOff, CC, PitchBend, ProgramChange, BankSelect };
+    Type type;
+    uint8_t bytes[3];
+    int numBytes;
+};
+
+struct NoteEntry {
+    int channel = 0;
+    int octave = 0;
+    char note = '.';
+    int velocity = 0;
+    int length = 0;
+    bool isPlayed = false;
+    bool active = false;
+};
+
+struct CcEntry {
+    enum CcType : uint8_t { TypeCC, TypePB, TypePG };
+    CcType type;
+    int channel = 0;
+    int knob = 0;
+    int value = 0;
+    int lsb = 0;
+    int msb = 0;
+    int bank = -1;
+    int sub = -1;
+    int pgm = -1;
+    bool active = false;
+};
+
+inline int clamp(int v, int min, int max) {
+    return v < min ? min : v > max ? max : v;
+}
+
+inline int valueOf(char g) {
+    if (g == '.' || g == '*' || g == 0) return 0;
+    char lower = (g >= 'A' && g <= 'Z') ? (g - 'A' + 'a') : g;
+    for (int i = 0; i < kNumKeys; i++) {
+        if (kKeys[i] == lower) return i;
+    }
+    return 0;
+}
+
+inline char keyOf(int val) {
+    int idx = ((val % kNumKeys) + kNumKeys) % kNumKeys;
+    return kKeys[idx];
+}
+
+inline bool isUpper(char c) {
+    return c >= 'A' && c <= 'Z';
+}
+
+inline char toLower(char c) {
+    return isUpper(c) ? (c - 'A' + 'a') : c;
+}
+
+inline char toUpper(char c) {
+    return (c >= 'a' && c <= 'z') ? (c - 'a' + 'A') : c;
+}
+
+inline bool isLetter(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+inline bool isDigitChar(char c) {
+    return c >= '0' && c <= '9';
+}
+
+inline bool isSpecial(char g) {
+    // A character is "special" if it has no case distinction (not a letter)
+    // and is not a digit or dot. Matches JS: g.toLowerCase() === g.toUpperCase() && isNaN(g)
+    return toLower(g) == toUpper(g) && !isDigitChar(g) && g != '.';
+}
+
+} // namespace orca


### PR DESCRIPTION
## Summary
- Port the Orca livecoding environment to a native AU/VST3 audio plugin using JUCE
- Full engine implementation: grid, all operators, MIDI output (host bus + virtual "Orca" port)
- Editor UI with grid rendering, cursor/selection, drag-and-drop and Cmd+O file loading, undo/redo, copy/paste
- Zoom support (Cmd+=/Cmd+-) with window auto-resize
- PPQ-synced transport to eliminate frame drift, with accumulator fallback
- Build system via CMake + Makefile (`make all` builds and installs AU/VST3)
- Updated .gitignore for C++/JUCE build artifacts, JUCE added as git submodule