### PR TITLE
Add Game of Life sequencer mode with JUCE plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ This builds and installs both the AU (`~/Library/Audio/Plug-Ins/Components/`) an
 | Shortcut | Action |
 |----------|--------|
 | `Cmd+O` | Open .orca file |
-| `Cmd+S` | Save as .orca file |
-| `Cmd+G` | Set groove ratios |
+| `Cmd+S` | Save as .orca/.life file |
+| `Cmd+L` | Import modules (load .orca/.life files into inject cache) |
+| `Cmd+G` | Toggle Life (Game of Life) mode |
+| `Cmd+K` | Open command prompt |
+| `Cmd+F` | Open command prompt with `find:` |
 | `Cmd+=` | Zoom in |
 | `Cmd+-` | Zoom out |
 | `Cmd+Z` | Undo |
@@ -55,9 +58,31 @@ This builds and installs both the AU (`~/Library/Audio/Plug-Ins/Components/`) an
 | `Cmd+C/V/X` | Copy/Paste/Cut |
 | `Backspace` | Delete selected cells |
 
-#### Plugin Parameters
+#### Plugin Parameters (DAW-Automatable)
 
-- **Shuffle** (0-200%): DAW-automatable swing parameter. 0% = max inverse swing, 100% = straight, 200% = max swing.
+All parameters are exposed via APVTS and can be automated from the DAW:
+
+| Group | Parameter | Range | Default | Description |
+|-------|-----------|-------|---------|-------------|
+| Shuffle | Shuffle | 0-200% | 100% | Swing amount (0%=inverse, 100%=straight, 200%=max) |
+| Life: Timing | Evolve Rate | 1-32 | 4 | Frames between evolutions |
+| Life: Timing | Seq Mode | Off/Forward/Reverse/Mirror/Random | Off | Sequencer mode variant |
+| Life: Timing | Pulse Mode | On/Off | On | Pulse (retrigger) vs Hold (sustain) |
+| Life: Pitch | Scale | 15 types | Chromatic | Active musical scale |
+| Life: Pitch | Root Note | C-B | C | Scale root note |
+| Life: Pitch | Min Octave | 0-8 | 0 | Lower octave limit |
+| Life: Pitch | Max Octave | 0-8 | 7 | Upper octave limit |
+| Life: Pitch | Lock Octave | On/Off | Off | Prevent octave drift on birth |
+| Life: Pitch | Chord Filter | Off/135/1357/125/145/1356/12356/1234567 | Off | Snap to chord degrees |
+| Life: Dynamics | Decay | On/Off | Off | Age-based velocity + probability drop |
+| Life: Dynamics | Min Velocity | 1-127 | 40 | Velocity floor at max age |
+| Life: Dynamics | Min Probability | 1-100% | 10 | Probability floor at max age |
+| Life: Dynamics | Max Notes | 0-32 | 0 | Per-channel per-step note cap (0=unlimited) |
+| Life: Processing | Dedup | On/Off | Off | Merge identical {channel, pitch} notes |
+| Life: Processing | Dedup CC | -1 to 127 | -1 | CC for dedup count modulation (-1=off) |
+| Life: Processing | CA Rule | Presets | Life | Cellular automata rule set |
+
+Commander commands and keyboard shortcuts write through APVTS, so changes are recorded in DAW automation lanes.
 
 #### MIDI Output
 
@@ -204,8 +229,9 @@ All commands have a shorthand equivalent to their first two characters, for exam
 - `write:H;12;34` Writes glyph `H`, at `12,34`(optional).
 - `time` Prints the time, in minutes seconds, since `0f`.
 - `midi:1;2` Set Midi output device to `#1`, and input device to `#2`.
-- `udp:1234;5678` Set UDP output port to `1234`, and input port to `5678`.
+- `udp:1234` Set UDP output port to `1234`.
 - `osc:1234` Set OSC output port to `1234`.
+- `ip:127.0.0.12` Set target IP for UDP/OSC output.
 - `groove:75;25` Set groove ratios (see [Groove](#groove)).
 
 ## Groove
@@ -241,6 +267,232 @@ Use the command prompt (`CmdOrCtrl+K`) and type `groove:75;25`.
 - **Shuffle slider**: A DAW-automatable parameter (0-200%) that maps to a 3-step groove. 0% = max inverse swing, 100% = straight, 200% = max swing.
 
 The current groove is displayed in the status bar as `groove:75;25;50`.
+
+#### Commander (Command Prompt)
+
+Press `Cmd+K` to open the command prompt, or `Cmd+F` to open with `find:` pre-filled. Type a command and press Enter to execute, or Escape to cancel. Up/Down arrows recall command history.
+
+All commands support 2-letter shorthands (first two characters).
+
+**Universal commands (both modes):**
+
+| Command | Short | Description |
+|---------|-------|-------------|
+| `find:text` | `fi` | Find text in grid and move cursor to first match |
+| `select:x;y;w;h` | `se` | Move cursor and optionally set selection size |
+| `write:text;x;y` | `wr` | Write text at position (or cursor if x;y omitted) |
+| `groove:75;25` | `gr` | Set groove ratios |
+| `cc:0` | `cc` | Set MIDI CC offset |
+| `pg:ch;msb;lsb;pgm` | `pg` | MIDI program change with optional bank select |
+| `copy` | `co` | Copy selection |
+| `paste` | `pa` | Paste clipboard |
+| `erase` | `er` | Erase selection |
+| `time` | `ti` | Write current time at cursor |
+| `color:f00;0f0;00f` | `cl` | Set theme colors (bLow;bMed;bHigh as hex RGB) |
+| `inject:name` | `in` | Inject cached module at cursor (or `inject:name;x;y`) |
+
+**Network commands:**
+
+| Command | Short | Description |
+|---------|-------|-------------|
+| `udp:7777` | `ud` | Set UDP output port |
+| `osc:7777` | `os` | Set OSC output port |
+| `ip:127.0.0.1` | `ip` | Set target IP address |
+| `osc:tidal` | -- | OSC preset for TidalCycles |
+| `osc:sonicpi` | -- | OSC preset for Sonic Pi |
+| `osc:supercollider` | -- | OSC preset for SuperCollider |
+| `osc:norns` | -- | OSC preset for Norns |
+
+**Life mode commands:**
+
+| Command | Short | Description |
+|---------|-------|-------------|
+| `scale:minor` | `sc` | Set scale by name |
+| `root:D` | `ro` | Set root note |
+| `rate:4` | `ra` | Set evolve rate (1-32) |
+| `pulse` / `hold` | `pu`/`ho` | Set note mode |
+| `channel:5` | `ch` | Set paint channel (0-15) |
+| `octave:4` | `oc` | Set paint octave |
+| `minoct:2` | `mi` | Set minimum octave limit |
+| `maxoct:6` | `mo` | Set maximum octave limit |
+| `decay` | `de` | Toggle decay system (velocity + probability drop with age) |
+| `minvel:60` | `mv` | Set floor velocity at max age (1-127, default 40) |
+| `minprob:10` | `mp` | Set floor fire probability at max age (1-100%, default 10) |
+| `maxnotes:4` | `mn` | Set max notes per step per channel (0=unlimited) |
+| `seq` | `sq` | Cycle sequencer mode: off → forward → reverse → mirror → random |
+| `lockoct` | `lo` | Toggle octave lock (prevent octave drift on birth) |
+| `chord` | `cd` | Toggle chord filter (off ↔ 135). Use `chord:1357`, `chord:125`, etc. for custom degrees |
+| `dedup` | `dd` | Toggle note deduplication (merge identical notes, scale velocity by count) |
+| `dedupcc:1` | `dc` | Set CC number for dedup count modulation (-1=disabled) |
+| `rule:23/36` | `ru` | Set CA rule in S/B notation (or preset: `life`, `highlife`, `34life`, `seeds`, `diamoeba`, `daynight`, `replicator`, `2x2`) |
+| `reset` | -- | Reset to initial state |
+
+The `$` (self) operator also sends commands through the commander. For example, `$groove:75;25` will set the groove when the `$` operator is banged.
+
+## Life Mode
+
+Orca includes a **Game of Life sequencer mode** — a completely different mode where the grid runs Conway's Game of Life rules with musical note cells. Cells are born, survive, and die according to GoL rules, triggering MIDI notes on birth and silencing on death.
+
+### Entering Life Mode
+
+Press `Cmd+G` to toggle between normal Orca mode and Life mode. In Life mode, the grid is replaced with a cellular automaton where each alive cell represents a musical note.
+
+### How It Works
+
+- **Alive cells** have a note (A-G), MIDI channel (0-15), and octave (0-7)
+- **Birth**: When a dead cell has exactly 3 alive neighbors, a new cell is born. Its note is derived by stepping up or down within the current scale, based on the direction of propagation relative to its parents
+- **Survival**: Cells with 2-3 neighbors survive
+- **Death**: Cells with fewer than 2 or more than 3 neighbors die, sending a MIDI note-off
+- **Toroidal wrapping**: The grid wraps around — patterns going off one edge reappear on the opposite side
+- **Protected cells**: Locked cells are immune to death rules, acting as permanent anchors
+
+### Modes
+
+- **Pulse mode** (default): Notes retrigger on every evolution step. Clusters of same-note cells produce ratchets (rapid sequential notes)
+- **Hold mode**: Notes trigger on birth and sustain until death
+
+### Scales
+
+Notes evolve within a selected scale. Available scales: chromatic, major, minor, pentatonic, dorian, phrygian, lydian, mixolydian, locrian, harmonic minor, melodic minor, minor pentatonic, blues, whole tone, diminished.
+
+### Decay
+
+**Decay** (`decay:on`) is a unified aging system that makes cells fade over time — both in volume and reliability:
+
+- **Newborn cells** play at full velocity (127) and always fire (100% probability)
+- **As cells age**, both velocity and probability decay linearly over 64 generations
+- At max age, velocity reaches `minvel` (default 40) and probability reaches `minprob` (default 10%)
+- `minvel:80` — raise the velocity floor (louder old cells)
+- `minprob:30` — raise the probability floor (more reliable old cells)
+- Models organic aging: young cells are loud and reliable, old cells become quiet and sporadic
+
+### Density Thinning
+
+**Max notes** (`maxnotes:N`) caps how many notes fire per step **per MIDI channel**:
+
+- `maxnotes:0` = unlimited (default)
+- `maxnotes:4` = at most 4 notes per channel per step
+- Prevents wall-of-notes from dense patterns while giving each channel its own budget
+
+### Sequencer Mode
+
+**Sequencer mode** (`seq`) transforms the grid into a step sequencer by staggering note emission across rows. Four variants are available — cycle through them with the `seq` command or automate via APVTS:
+
+| Variant | Description |
+|---------|-------------|
+| `seq:forward` | Top-to-bottom scan (default seq behavior) |
+| `seq:reverse` | Bottom-to-top scan |
+| `seq:mirror` | Ping-pong — alternates direction each evolution cycle |
+| `seq:random` | Random row order, reshuffled each evolution |
+
+- Instead of all rows firing simultaneously, each row group fires on a different frame within the evolve cycle
+- With `rate:8` and 16 rows: rows 0-1 fire on frame 0, rows 2-3 on frame 1, etc.
+- Visual guides show phase group boundaries; a sweeping highlight shows the active row group
+- Later rows naturally get shorter notes, reinforcing the sequential feel
+- Disables ratchet clustering (cells fire individually with phase scheduling)
+- No effect when `rate:1`
+
+### Octave Lock
+
+**Octave lock** (`lockoct:on`) prevents octave drift during note evolution. When cells are born, their note still evolves by stepping through the scale, but the octave stays locked to the parent median. Useful in sequencer mode to keep patterns in their intended register.
+
+### Chord Tone Filter
+
+**Chord filter** snaps all emitted notes to the nearest chord tone of the current scale. This dramatically reduces dissonance by ensuring everything aligns harmonically:
+
+- `chord` (toggle) — cycles between off and triad (degrees 1, 3, 5)
+- `chord:135` — triad (root, 3rd, 5th)
+- `chord:1357` — seventh chord (root, 3rd, 5th, 7th)
+- `chord:125` — sus2 voicing
+- `chord:145` — sus4 voicing
+- `chord:1356` — sixth chord
+- `chord:12356` — add2 chord
+- `chord:1234567` — full scale (all degrees allowed)
+- Custom degrees can be specified as any combination of digits 1-7
+
+Works with any scale — for pentatonic scales (5 notes or fewer), all notes are considered chord tones. Especially effective with dense patterns that would otherwise produce clashing intervals.
+
+### Note Deduplication
+
+**Dedup** (`dedup:on`) merges identical `{channel, pitch}` notes into a single note, scaling velocity by the number of cells:
+
+- **Velocity**: average velocity of all contributing cells + log2(count) × 15 boost. With decay on, this preserves the age-based variation while rewarding density
+- **CC modulation** (optional): `dedupcc:1` sends CC1 (mod wheel) proportional to the count (8 cells = CC 127). Map this to filter cutoff or expression in your synth for timbral variation. Disabled by default (`dedupcc:-1`)
+- Especially useful with dense patterns where many cells converge on the same note — instead of firing 5 identical C3s, fires one louder C3
+- Pairs well with decay: average velocity keeps age dynamics, count boost rewards density
+
+### Cellular Automata Rules
+
+By default, Life mode uses Conway's Game of Life (B3/S23). You can change the rules with the `rule` command:
+
+| Preset | S/B Notation | Description |
+|--------|-------------|-------------|
+| `life` | 23/3 | Conway's Game of Life (default) |
+| `highlife` | 23/36 | Self-replicating patterns |
+| `34life` | 34/34 | Exploding/chaotic growth |
+| `seeds` | /2 | All cells die, birth with 2 neighbors |
+| `diamoeba` | 5678/35678 | Diamond-shaped amoeba patterns |
+| `daynight` | 3678/3678 | Symmetric day/night behavior |
+| `replicator` | 1357/1357 | Self-replicating patterns |
+| `2x2` | 125/36 | 2×2 block patterns |
+| `morley` | 245/368 | Move/Morley |
+
+Custom rules: `rule:23/36` — digits before `/` are survival counts, after `/` are birth counts.
+
+### Octave Range
+
+Control the octave range with `minoct:N` and `maxoct:N`:
+
+- `minoct:2` — no notes below octave 2
+- `maxoct:5` — no notes above octave 5
+- Born cells are clamped to the active range
+- Octave cycling (Tab) wraps within the range
+- Tighter ranges reduce dissonance from extreme octave spread
+
+### Pattern Library
+
+Life mode includes a library of classic GoL patterns organized by category:
+- **Still Lifes** (11): Block, Beehive, Loaf, Boat, Tub, Pond, Ship, Long Boat, Barge, Mango, Eater 1
+- **Oscillators** (14): Blinker, Toad, Beacon, Pulsar, Pentadecathlon, Clock, Octagon 2, Figure 8, Tumbler, Fumarole, Queen Bee Shuttle, Twin Bees Shuttle, Ants, Turning Toads
+- **Spaceships** (9): Glider (4 directions), LWSS, MWSS, HWSS, Copperhead, Loafer
+- **Methuselahs** (9): R-pentomino, Diehard, Acorn, Pi, B-heptomino, Thunderbird, Herschel, Rabbits, Lidka
+- **Guns** (3): Gosper Gun, Simkin Gun, Simkin Gun 1B
+- **Puffers** (2): Puffer 1, Switchengine
+
+Patterns are placed with random notes from the current scale, using the active paint channel and octave.
+
+### Life Mode Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+G` | Toggle Life mode on/off |
+| `A-G` / `a-g` | Place a note cell |
+| `Tab` | Cycle paint octave |
+| `Shift+Tab` | Cycle paint channel |
+| `Cmd+Shift+S` | Cycle scale |
+| `Cmd+N` | Cycle root note (C, C#, D, ... B) |
+| `Cmd+M` | Toggle pulse/hold mode |
+| `Cmd+Shift+Up/Down` | Double/halve evolve rate |
+| `Cmd+Shift+K` | Toggle lock (protect) selected cells |
+| `Cmd+P` | Enter stamp mode / cycle pattern within category |
+| `Cmd+Shift+P` | Cycle pattern backward within category |
+| `Cmd+]` / `Cmd+[` | Cycle pattern category |
+| `Enter` (stamp mode) | Place pattern |
+| `Escape` (stamp mode) | Cancel stamp mode |
+| `Cmd+E` | Rotate selection 90° clockwise |
+| `Cmd+Shift+H` | Mirror selection horizontal |
+| `Cmd+Shift+J` | Mirror selection vertical |
+| `Cmd+Up/Down` | Shift octave of selected cells |
+| `Cmd+Left/Right` | Shift channel of selected cells |
+| `Cmd+R` | Reset to initial state |
+| `Cmd+Shift+R` | Save current state as new initial |
+| `Cmd+Z` | Undo |
+| `Cmd+Shift+Z` | Redo |
+| `Cmd+S` | Save as .life file |
+
+### .life File Format
+
+Life mode uses its own file format (`.life`) separate from `.orca` files. Files can be saved with `Cmd+S` and loaded via drag-and-drop. The format stores grid dimensions, cell data (note, channel, octave, lock state), and all settings (scale, root, evolve rate, pulse mode, decay, min velocity, min probability, max notes, sequencer mode, octave lock, chord filter, dedup, dedup CC, min/max octave, CA rule).
 
 ## Base36 Table
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ All parameters are exposed via APVTS and can be automated from the DAW:
 | Life: Processing | Dedup | On/Off | Off | Merge identical {channel, pitch} notes |
 | Life: Processing | Dedup CC | -1 to 127 | -1 | CC for dedup count modulation (-1=off) |
 | Life: Processing | CA Rule | Presets | Life | Cellular automata rule set |
+| Life: Timing | Conductor | On/Off | Off | Manual evolution via trigger (Enter/MIDI) |
+| Life: Pitch | Microtune | On/Off | Off | Pitch bend based on neighbor count |
+| Life: Pitch | Microtune Amount | 0-100 | 50 | Pitch bend intensity |
 
 Commander commands and keyboard shortcuts write through APVTS, so changes are recorded in DAW automation lanes.
 
@@ -325,6 +328,12 @@ All commands support 2-letter shorthands (first two characters).
 | `dedup` | `dd` | Toggle note deduplication (merge identical notes, scale velocity by count) |
 | `dedupcc:1` | `dc` | Set CC number for dedup count modulation (-1=disabled) |
 | `rule:23/36` | `ru` | Set CA rule in S/B notation (or preset: `life`, `highlife`, `34life`, `seeds`, `diamoeba`, `daynight`, `replicator`, `2x2`) |
+| `conductor` | `cn` | Toggle conductor mode (manual evolution) |
+| `microtune` | `mt` | Toggle microtuning pitch bend |
+| `microtune:75` | `mt` | Set microtune amount (0-100) |
+| `loop:8` | `lp` | Arm loop recording for N generations (auto-plays when done) |
+| `loop:stop` | `lp` | Stop loop playback |
+| `loop` | `lp` | Toggle loop playback on/off |
 | `reset` | -- | Reset to initial state |
 
 The `$` (self) operator also sends commands through the commander. For example, `$groove:75;25` will set the groove when the `$` operator is banged.
@@ -439,6 +448,42 @@ By default, Life mode uses Conway's Game of Life (B3/S23). You can change the ru
 
 Custom rules: `rule:23/36` — digits before `/` are survival counts, after `/` are birth counts.
 
+### Conductor Mode
+
+**Conductor mode** (`conductor` or `Cmd+T`) gives you manual control over when the grid evolves. Instead of evolving automatically every N frames, the grid only advances when you trigger it:
+
+- **Enter key**: Press Enter to trigger one evolution step
+- **External MIDI**: Any MIDI NoteOn received by the plugin triggers one evolution step — connect a keyboard, sequencer, or another plugin to control the pace externally
+
+When combined with **sequencer mode**, the sequencer continues scanning rows independently at the evolve rate, but the GoL rules (birth/death/survival) only fire on trigger. This lets you keep the rhythmic pulse going while deciding when the pattern should evolve.
+
+Mid-cycle triggers are supported: if you press Enter while the sequencer is mid-scan, the grid evolves immediately without disturbing the current seq phase.
+
+### Microtuning
+
+**Microtuning** (`microtune` or `Cmd+U`) adds pitch bend messages before each note based on how many neighbors that cell has:
+
+- Cells with **2 neighbors** (the GoL equilibrium) get no bend (center = 8192)
+- Cells with **fewer neighbors** bend downward
+- Cells with **more neighbors** bend upward
+- `microtune:75` sets the bend intensity (0-100, default 50)
+
+This creates organic pitch variation tied to the local density of the cellular automaton — isolated cells sound slightly flat while crowded cells sound sharp. The pitch bend is channel-wide (per MIDI spec), so it affects all notes on that channel.
+
+### Generation Loop
+
+**Generation loop** records a sequence of evolution snapshots and loops them back:
+
+1. `loop:8` — arms recording for the next 8 evolutions
+2. As the grid evolves, each generation's grid state and MIDI events are captured
+3. When recording completes, playback starts automatically — the grid cycles through the recorded generations instead of running live GoL rules
+4. `loop:stop` or `Cmd+E` — stops playback and returns to live evolution
+5. `loop` (bare) or `Cmd+E` — toggles playback on/off
+
+The loop stores full grid snapshots (including ratchets and phase notes for seq mode), so playback is faithful to the original recording. Up to 64 generations can be recorded.
+
+Status bar shows `loop:rec 3/8` during recording and `loop:5/8` during playback.
+
 ### Octave Range
 
 Control the octave range with `minoct:N` and `maxoct:N`:
@@ -477,9 +522,12 @@ Patterns are placed with random notes from the current scale, using the active p
 | `Cmd+P` | Enter stamp mode / cycle pattern within category |
 | `Cmd+Shift+P` | Cycle pattern backward within category |
 | `Cmd+]` / `Cmd+[` | Cycle pattern category |
+| `Enter` (conductor) | Trigger evolution |
 | `Enter` (stamp mode) | Place pattern |
 | `Escape` (stamp mode) | Cancel stamp mode |
-| `Cmd+E` | Rotate selection 90° clockwise |
+| `Cmd+E` | Toggle loop playback / Rotate selection 90° clockwise |
+| `Cmd+T` | Toggle conductor mode |
+| `Cmd+U` | Toggle microtuning |
 | `Cmd+Shift+H` | Mirror selection horizontal |
 | `Cmd+Shift+J` | Mirror selection vertical |
 | `Cmd+Up/Down` | Shift octave of selected cells |

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(OrcaPlugin
     PRIVATE
         juce::juce_audio_utils
         juce::juce_gui_basics
+        juce::juce_osc
         ${COREMIDI_FRAMEWORK}
         ${AUDIOTOOLBOX_FRAMEWORK}
     PUBLIC

--- a/plugin/Source/Commander.h
+++ b/plugin/Source/Commander.h
@@ -1,0 +1,201 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+// Forward declarations
+class OrcaProcessor;
+class GridComponent;
+
+class Commander {
+public:
+    bool isActive = false;
+    juce::String query;
+    int cursorPos = 0; // cursor position within query
+
+    // Command history
+    static constexpr int kMaxHistory = 32;
+    juce::String commandHistory[kMaxHistory];
+    int historyCount = 0;
+    int historyIndex = -1;
+
+    // Find preview state
+    juce::Array<int> findHighlights; // cell indices that match find query
+    bool hasFindPreview = false;
+
+    void start(const juce::String& prefill = "") {
+        isActive = true;
+        query = prefill;
+        cursorPos = query.length();
+        historyIndex = -1;
+        findHighlights.clear();
+        hasFindPreview = false;
+    }
+
+    void stop() {
+        isActive = false;
+        query.clear();
+        cursorPos = 0;
+        findHighlights.clear();
+        hasFindPreview = false;
+    }
+
+    void write(juce::juce_wchar ch) {
+        query = query.substring(0, cursorPos)
+              + juce::String::charToString(ch)
+              + query.substring(cursorPos);
+        cursorPos++;
+    }
+
+    void erase() {
+        if (cursorPos > 0) {
+            query = query.substring(0, cursorPos - 1) + query.substring(cursorPos);
+            cursorPos--;
+        }
+    }
+
+    void eraseForward() {
+        if (cursorPos < query.length())
+            query = query.substring(0, cursorPos) + query.substring(cursorPos + 1);
+    }
+
+    void moveCursorLeft()  { if (cursorPos > 0) cursorPos--; }
+    void moveCursorRight() { if (cursorPos < query.length()) cursorPos++; }
+    void moveCursorHome()  { cursorPos = 0; }
+    void moveCursorEnd()   { cursorPos = query.length(); }
+
+    // Move cursor to previous/next word boundary
+    void moveCursorWordLeft() {
+        if (cursorPos == 0) return;
+        cursorPos--;
+        while (cursorPos > 0 && query[cursorPos - 1] != ' ' && query[cursorPos - 1] != ':' && query[cursorPos - 1] != ';')
+            cursorPos--;
+    }
+
+    void moveCursorWordRight() {
+        int len = query.length();
+        if (cursorPos >= len) return;
+        cursorPos++;
+        while (cursorPos < len && query[cursorPos] != ' ' && query[cursorPos] != ':' && query[cursorPos] != ';')
+            cursorPos++;
+    }
+
+    // Select all text (for Cmd+A)
+    void selectAll() { cursorPos = query.length(); }
+
+    // Replace entire query (for paste)
+    void replaceQuery(const juce::String& text) {
+        query = text;
+        cursorPos = query.length();
+    }
+
+    // Insert text at cursor (for paste)
+    void insertAtCursor(const juce::String& text) {
+        query = query.substring(0, cursorPos) + text + query.substring(cursorPos);
+        cursorPos += text.length();
+    }
+
+    // Delete from cursor to end (Cmd+K / Ctrl+K)
+    void killToEnd() {
+        query = query.substring(0, cursorPos);
+    }
+
+    // Delete from start to cursor (Cmd+U / Ctrl+U)
+    void killToStart() {
+        query = query.substring(cursorPos);
+        cursorPos = 0;
+    }
+
+    void historyUp() {
+        if (historyCount == 0) return;
+        if (historyIndex < historyCount - 1) historyIndex++;
+        query = commandHistory[historyIndex];
+        cursorPos = query.length();
+    }
+
+    void historyDown() {
+        if (historyIndex > 0) {
+            historyIndex--;
+            query = commandHistory[historyIndex];
+        } else if (historyIndex == 0) {
+            historyIndex = -1;
+            query.clear();
+        }
+        cursorPos = query.length();
+    }
+
+    void pushToHistory(const juce::String& cmd) {
+        if (cmd.isEmpty()) return;
+        // Shift history down
+        int limit = (historyCount < kMaxHistory) ? historyCount : kMaxHistory - 1;
+        for (int i = limit; i > 0; i--)
+            commandHistory[i] = commandHistory[i - 1];
+        commandHistory[0] = cmd;
+        if (historyCount < kMaxHistory) historyCount++;
+    }
+
+    // Parse and execute command. Returns true if valid.
+    // Implementation is in PluginEditor.cpp since it needs access to processor/editor.
+    bool trigger(OrcaProcessor& processor, GridComponent& editor);
+
+    // Update passive previews (find highlighting)
+    void preview(OrcaProcessor& processor, GridComponent& editor);
+
+private:
+    // Parse "command:value" from query
+    struct ParsedCommand {
+        juce::String name;
+        juce::String value;
+        juce::StringArray parts; // value split by ';'
+    };
+
+    ParsedCommand parse() const {
+        ParsedCommand result;
+        int colonIdx = query.indexOfChar(':');
+        if (colonIdx >= 0) {
+            result.name = query.substring(0, colonIdx).toLowerCase();
+            result.value = query.substring(colonIdx + 1);
+            result.parts = juce::StringArray::fromTokens(result.value, ";", "");
+        } else {
+            result.name = query.toLowerCase().trim();
+        }
+
+        // 2-letter shorthand expansion
+        if (result.name.length() == 2) {
+            auto sh = result.name;
+            if (sh == "fi") result.name = "find";
+            else if (sh == "se") result.name = "select";
+            else if (sh == "wr") result.name = "write";
+            else if (sh == "gr") result.name = "groove";
+            else if (sh == "er") result.name = "erase";
+            else if (sh == "co") result.name = "copy";
+            else if (sh == "pa") result.name = "paste";
+            else if (sh == "cl") result.name = "color";
+            else if (sh == "ti") result.name = "time";
+            else if (sh == "sc") result.name = "scale";
+            else if (sh == "ro") result.name = "root";
+            else if (sh == "ra") result.name = "rate";
+            else if (sh == "pu") result.name = "pulse";
+            else if (sh == "ho") result.name = "hold";
+            else if (sh == "ch") result.name = "channel";
+            else if (sh == "oc") result.name = "octave";
+            else if (sh == "mo") result.name = "maxoct";
+            else if (sh == "mi") result.name = "minoct";
+            else if (sh == "in") result.name = "inject";
+            else if (sh == "pg") result.name = "pg";
+            else if (sh == "ud") result.name = "udp";
+            else if (sh == "os") result.name = "osc";
+            else if (sh == "ip") result.name = "ip";
+            else if (sh == "de") result.name = "decay";
+            else if (sh == "mv") result.name = "minvel";
+            else if (sh == "mp") result.name = "minprob";
+            else if (sh == "mn") result.name = "maxnotes";
+            else if (sh == "sq") result.name = "seq";
+            else if (sh == "lo") result.name = "lockoct";
+            else if (sh == "cd") result.name = "chord";
+            else if (sh == "dd") result.name = "dedup";
+            else if (sh == "dc") result.name = "dedupcc";
+            else if (sh == "ru") result.name = "rule";
+        }
+        return result;
+    }
+};

--- a/plugin/Source/Commander.h
+++ b/plugin/Source/Commander.h
@@ -195,6 +195,9 @@ private:
             else if (sh == "dd") result.name = "dedup";
             else if (sh == "dc") result.name = "dedupcc";
             else if (sh == "ru") result.name = "rule";
+            else if (sh == "cn") result.name = "conductor";
+            else if (sh == "mt") result.name = "microtune";
+            else if (sh == "lp") result.name = "loop";
         }
         return result;
     }

--- a/plugin/Source/PluginEditor.cpp
+++ b/plugin/Source/PluginEditor.cpp
@@ -1,5 +1,16 @@
 #include "PluginEditor.h"
 
+// Stamp pattern categories
+static constexpr struct StampCategoryDef { int start; int count; const char* name; } stampCategories[] = {
+    { 0,  11, "Still Lifes" },
+    { 11, 14, "Oscillators" },
+    { 25,  9, "Spaceships" },
+    { 34,  9, "Methuselahs" },
+    { 43,  3, "Guns" },
+    { 46,  2, "Puffers" },
+};
+static constexpr int numStampCategories = 6;
+
 // ── GridComponent ──
 
 GridComponent::GridComponent(OrcaProcessor& p)
@@ -12,10 +23,15 @@ GridComponent::GridComponent(OrcaProcessor& p)
     updateFontSize(fontSize);
 }
 
+void GridComponent::visibilityChanged() {
+    if (isVisible())
+        grabKeyboardFocus();
+}
+
 GridComponent::~GridComponent() {
     stopTimer();
-    // Cancel any pending async file chooser to prevent callback on a dead object
     fileChooser.reset();
+    delete[] lifeHistory;
 }
 
 void GridComponent::paint(juce::Graphics& g) {
@@ -27,15 +43,77 @@ void GridComponent::paint(juce::Graphics& g) {
 
     g.setFont(monoFont);
 
+    // Phase offset: row group guides + active phase highlight
+    if (engine.lifeMode && engine.lifeGrid.seqMode != orca::LifeGrid::SeqOff && engine.lifeGrid.evolveRate > 1) {
+        int currentFrame = engine.lifeGrid.frameCounter;
+        float totalW = gridW * tileW;
+
+        // Draw separator lines between phase groups
+        int prevPhase = -1;
+        for (int y = 0; y < gridH; y++) {
+            int ph = engine.lifeGrid.phaseForRow(y);
+            if (ph != prevPhase && prevPhase >= 0) {
+                float ly = y * tileH;
+                g.setColour(juce::Colour(0x30ffffff));
+                g.fillRect(0.0f, ly, totalW, 1.0f);
+            }
+            prevPhase = ph;
+        }
+
+        // Highlight the active phase rows
+        for (int y = 0; y < gridH; y++) {
+            if (engine.lifeGrid.phaseForRow(y) == currentFrame) {
+                float py = y * tileH;
+                g.setColour(juce::Colour(0x15ffffff));
+                g.fillRect(0.0f, py, totalW, tileH);
+            }
+        }
+    }
+
     for (int y = 0; y < gridH; y++) {
         for (int x = 0; x < gridW; x++) {
             int idx = x + gridW * y;
-            char glyph = engine.shadowCells[idx];
-            uint8_t portType = engine.shadowPorts[idx];
-            bool isLocked = engine.shadowLocks[idx];
-            bool isSelected = (x >= cursorX && x < cursorX + selectW &&
-                               y >= cursorY && y < cursorY + selectH);
-            drawCell(g, x, y, glyph, portType, isLocked, isSelected);
+            bool isSelected = !stampMode &&
+                               (x >= cursorX && x < cursorX + selectW &&
+                                y >= cursorY && y < cursorY + selectH);
+            if (engine.lifeMode) {
+                drawLifeCell(g, x, y, engine.shadowLife[idx], isSelected);
+            } else {
+                char glyph = engine.shadowCells[idx];
+                uint8_t portType = engine.shadowPorts[idx];
+                bool isLocked = engine.shadowLocks[idx];
+                drawCell(g, x, y, glyph, portType, isLocked, isSelected);
+            }
+        }
+    }
+
+    // Draw stamp mode ghost overlay
+    if (stampMode && engine.lifeMode) {
+        auto& p = orca::builtInPatterns[stampIndex];
+        auto channelCol = juce::Colour(channelColorValues[engine.paintChannel % 16]);
+        for (int py = 0; py < p.h; py++) {
+            for (int px = 0; px < p.w; px++) {
+                int srcIdx = px + p.w * py;
+                if (p.data[srcIdx] != 'X') continue;
+                int gx = cursorX + px, gy = cursorY + py;
+                if (gx >= gridW || gy >= gridH) continue;
+                float cellX = gx * tileW;
+                float cellY = gy * tileH;
+                g.setColour(channelCol.withAlpha(0.35f));
+                g.fillRect(cellX, cellY, tileW, tileH);
+                g.setColour(channelCol.withAlpha(0.7f));
+                g.drawRect(cellX, cellY, tileW, tileH, 1.0f);
+            }
+        }
+    }
+
+    // Draw find preview highlights
+    if (commander.hasFindPreview && commander.findHighlights.size() > 0) {
+        g.setColour(bMed.withAlpha(0.4f));
+        for (int idx : commander.findHighlights) {
+            int hx = idx % gridW;
+            int hy = idx / gridW;
+            g.fillRect(hx * tileW, hy * tileH, tileW, tileH);
         }
     }
 
@@ -43,65 +121,148 @@ void GridComponent::paint(juce::Graphics& g) {
     {
         float cx = cursorX * tileW;
         float cy = cursorY * tileH;
-        g.setColour(bInv);
-        g.fillRect(cx, cy, tileW, tileH);
-        g.setColour(fInv);
-        char curGlyphUnder = '.';
-        if (cursorX < gridW && cursorY < gridH)
-            curGlyphUnder = engine.shadowCells[cursorX + gridW * cursorY];
-        char cursorChar = (curGlyphUnder != '.') ? curGlyphUnder : '@';
-        g.drawText(juce::String::charToString(cursorChar),
-                   (int)cx, (int)cy, (int)tileW, (int)tileH,
-                   juce::Justification::centred);
+        if (stampMode) {
+            // In stamp mode, just draw a subtle outline so the pattern preview is visible
+            g.setColour(juce::Colour(0x88ffffff));
+            g.drawRect(cx, cy, tileW, tileH, 1.0f);
+        } else {
+            g.setColour(bInv);
+            g.fillRect(cx, cy, tileW, tileH);
+            g.setColour(fInv);
+            char curGlyphUnder = '.';
+            if (cursorX < gridW && cursorY < gridH)
+                curGlyphUnder = engine.shadowCells[cursorX + gridW * cursorY];
+            char cursorChar = (curGlyphUnder != '.') ? curGlyphUnder : '@';
+            g.drawText(juce::String::charToString(cursorChar),
+                       (int)cx, (int)cy, (int)tileW, (int)tileH,
+                       juce::Justification::centred);
+        }
     }
 
-    // Two-line status bar (matches original Orca layout)
+    // Two-line status bar
     g.setFont(monoFont);
     float statusY = getHeight() - 30.0f;
 
-    // Get glyph and port info under cursor
-    char curGlyph = '.';
-    uint8_t curPort = 0;
-    char curPortOwner = 0;
-    uint8_t curPortIdx = 0;
-    if (cursorX < gridW && cursorY < gridH) {
-        int ci = cursorX + gridW * cursorY;
-        curGlyph = engine.shadowCells[ci];
-        curPort = engine.shadowPorts[ci];
-        curPortOwner = engine.shadowPortOwner[ci];
-        curPortIdx = engine.shadowPortIdx[ci];
-    }
+    if (commander.isActive) {
+        // Commander prompt overlay — draw text with inline cursor
+        g.setColour(bInv);
+        juce::String prefix = "> ";
+        juce::String before = prefix + commander.query.substring(0, commander.cursorPos);
+        juce::String after  = commander.query.substring(commander.cursorPos);
 
-    // Line 1: operator_name (+ port_name if on a port)  cursor_pos  frame
-    {
-        g.setColour(fMed);
-        juce::String line1;
-        if (curPort > 0 && curPort != 10 && curPortOwner != 0) {
-            // Cursor is on a port — show "ownerName portName"
-            line1 << operatorName(curPortOwner) << " " << portName(curPortOwner, curPortIdx);
-        } else {
-            line1 << operatorName(curGlyph);
-        }
-        line1 << "   " << cursorX << "," << cursorY
-              << "   " << engine.shadowF << "f";
-        g.drawText(line1, 4, (int)statusY, getWidth() - 8, 14,
+        // Measure text widths to position cursor
+        auto font = g.getCurrentFont();
+        float beforeW = font.getStringWidthFloat(before);
+        float cursorX = 4.0f + beforeW;
+
+        // Draw full text
+        g.drawText(prefix + commander.query, 4, (int)statusY, getWidth() - 8, 14,
                    juce::Justification::centredLeft);
-    }
 
-    // Line 2: grid_size + groove info
-    {
+        // Draw blinking cursor bar
+        if (engine.shadowF % 2 == 0) {
+            g.fillRect(cursorX, statusY + 1.0f, 1.5f, 12.0f);
+        }
+
+        // Second line: hint
         g.setColour(fLow);
-        juce::String line2;
-        line2 << gridW << "x" << gridH;
-        if (processor.grooveLength > 1) {
-            line2 << "   groove:";
-            for (int i = 0; i < processor.grooveLength; i++) {
-                if (i > 0) line2 << ";";
-                line2 << (int)std::round(processor.grooves[i] * 50.0);
+        g.drawText("Enter to execute, Esc to cancel", 4, (int)(statusY + 14),
+                   getWidth() - 8, 14, juce::Justification::centredLeft);
+    } else if (engine.lifeMode) {
+        // Life mode status bar
+        // Line 1: LIFE  ch:X  oct:X  cursor_pos  generation
+        {
+            g.setColour(juce::Colour(channelColorValues[engine.paintChannel % 16]));
+            juce::String line1;
+            line1 << "LIFE  ch:" << (int)engine.paintChannel
+                  << "  oct:" << (int)engine.paintOctave
+                  << "  " << orca::LifeGrid::rootNoteName(engine.lifeGrid.rootNote)
+                  << " " << orca::LifeGrid::scaleName(engine.lifeGrid.currentScale)
+                  << "  " << (engine.lifeGrid.pulseMode ? "pulse" : "hold")
+                  << "  rate:" << engine.lifeGrid.evolveRate
+                  << (engine.lifeGrid.decay ? juce::String("  decay:") + juce::String((int)engine.lifeGrid.minVelocity) + "v/" + juce::String(engine.lifeGrid.minProb) + "%" : juce::String())
+                  << (engine.lifeGrid.maxNotes > 0 ? juce::String("  max:") + juce::String(engine.lifeGrid.maxNotes) : juce::String())
+                  << (engine.lifeGrid.seqMode == orca::LifeGrid::SeqForward ? "  seq" :
+                      engine.lifeGrid.seqMode == orca::LifeGrid::SeqReverse ? "  seq:rev" :
+                      engine.lifeGrid.seqMode == orca::LifeGrid::SeqMirror ? "  seq:mirror" :
+                      engine.lifeGrid.seqMode == orca::LifeGrid::SeqRandom ? "  seq:random" : "")
+                  << (engine.lifeGrid.lockOctave ? "  lockoct" : "")
+                  << (engine.lifeGrid.chordDegreeCount > 0 ? juce::String("  chord:") + engine.lifeGrid.chordDegreesString() : juce::String())
+                  << (engine.lifeGrid.dedup ? juce::String("  dedup") + (engine.lifeGrid.dedupCC >= 0 ? juce::String(" cc:") + juce::String(engine.lifeGrid.dedupCC) : juce::String()) : juce::String())
+                  << (strcmp(engine.lifeGrid.ruleString, "23/3") != 0 ? juce::String("  rule:") + juce::String(engine.lifeGrid.ruleString) : juce::String())
+                  << ((engine.lifeGrid.minOctave != 0 || engine.lifeGrid.maxOctave != 7) ?
+                      juce::String("  oct:") + juce::String(engine.lifeGrid.minOctave) + "-" + juce::String(engine.lifeGrid.maxOctave) :
+                      juce::String())
+                  << "   " << cursorX << "," << cursorY
+                  << "   gen:" << engine.shadowF;
+            {
             }
+            if (stampMode)
+                line1 << "   STAMP: " << stampCategories[stampCategory].name
+                      << " > " << orca::builtInPatterns[stampIndex].name;
+            g.drawText(line1, 4, (int)statusY, getWidth() - 8, 14,
+                       juce::Justification::centredLeft);
         }
-        g.drawText(line2, 4, (int)(statusY + 14), getWidth() - 8, 14,
-                   juce::Justification::centredLeft);
+        // Line 2: grid_size  population
+        {
+            g.setColour(fLow);
+            juce::String line2;
+            line2 << gridW << "x" << gridH
+                  << "   pop:" << engine.lifeGrid.population()
+                  << "   udp:" << processor.udpOutputPort
+                  << "  osc:" << processor.oscOutputPort;
+            g.drawText(line2, 4, (int)(statusY + 14), getWidth() - 8, 14,
+                       juce::Justification::centredLeft);
+        }
+    } else {
+        // Normal Orca status bar
+        // Get glyph and port info under cursor
+        char curGlyph = '.';
+        uint8_t curPort = 0;
+        char curPortOwner = 0;
+        uint8_t curPortIdx = 0;
+        if (cursorX < gridW && cursorY < gridH) {
+            int ci = cursorX + gridW * cursorY;
+            curGlyph = engine.shadowCells[ci];
+            curPort = engine.shadowPorts[ci];
+            curPortOwner = engine.shadowPortOwner[ci];
+            curPortIdx = engine.shadowPortIdx[ci];
+        }
+
+        // Line 1: operator_name (+ port_name if on a port)  cursor_pos  frame
+        {
+            g.setColour(fMed);
+            juce::String line1;
+            if (curPort > 0 && curPort != 10 && curPortOwner != 0) {
+                line1 << operatorName(curPortOwner) << " " << portName(curPortOwner, curPortIdx);
+            } else {
+                line1 << operatorName(curGlyph);
+            }
+            line1 << "   " << cursorX << "," << cursorY
+                  << "   " << engine.shadowF << "f";
+            g.drawText(line1, 4, (int)statusY, getWidth() - 8, 14,
+                       juce::Justification::centredLeft);
+        }
+
+        // Line 2: grid_size + groove info
+        {
+            g.setColour(fLow);
+            juce::String line2;
+            line2 << gridW << "x" << gridH;
+            if (processor.grooveLength > 1) {
+                line2 << "   groove:";
+                for (int i = 0; i < processor.grooveLength; i++) {
+                    if (i > 0) line2 << ";";
+                    line2 << (int)std::round(processor.grooves[i] * 50.0);
+                }
+            }
+            if (!injectCache.empty())
+                line2 << "   " << (int)injectCache.size() << " mods";
+            line2 << "   udp:" << processor.udpOutputPort
+                  << "  osc:" << processor.oscOutputPort;
+            g.drawText(line2, 4, (int)(statusY + 14), getWidth() - 8, 14,
+                       juce::Justification::centredLeft);
+        }
     }
 }
 
@@ -188,6 +349,64 @@ void GridComponent::drawCell(juce::Graphics& g, int x, int y, char glyph,
     }
 }
 
+void GridComponent::drawLifeCell(juce::Graphics& g, int x, int y,
+                                  const orca::LifeCell& cell, bool isSelected) {
+    float px = x * tileW;
+    float py = y * tileH;
+
+    if (isSelected) {
+        g.setColour(bInv);
+        g.fillRect(px, py, tileW, tileH);
+        g.setColour(fInv);
+        char ch = cell.alive ? cell.note : '.';
+        g.drawText(juce::String::charToString(ch),
+                   (int)px, (int)py, (int)tileW, (int)tileH,
+                   juce::Justification::centred);
+        return;
+    }
+
+    if (!cell.alive) {
+        // Dead cell: show grid markers like normal mode
+        bool isMarker = (x % 8 == 0 && y % 8 == 0);
+        bool isLocalGuide = (x % 2 == 0 && y % 2 == 0) &&
+                            (std::abs(x - cursorX) <= 6 && std::abs(y - cursorY) <= 6);
+        if (isMarker) {
+            g.setColour(fLow);
+            g.drawText("+", (int)px, (int)py, (int)tileW, (int)tileH,
+                       juce::Justification::centred);
+        } else if (isLocalGuide) {
+            g.setColour(fLow);
+            float dotX = px + tileW * 0.5f;
+            float dotY = py + tileH * 0.5f;
+            g.fillRect(dotX, dotY, 1.0f, 1.0f);
+        }
+        return;
+    }
+
+    // Alive cell: color by channel hue, brightness by octave
+    juce::Colour baseCol(channelColorValues[cell.channel % 16]);
+    // minOctave = 30% brightness, maxOctave = 100%
+    float range = juce::jmax(1.0f, (float)(processor.engine.lifeGrid.maxOctave - processor.engine.lifeGrid.minOctave));
+    float brightness = 0.3f + ((cell.octave - processor.engine.lifeGrid.minOctave) / range) * 0.7f;
+    juce::Colour col = baseCol.withMultipliedBrightness(brightness);
+
+    g.setColour(col);
+    g.fillRect(px, py, tileW, tileH);
+    // Draw note letter in white
+    g.setColour(juce::Colour(0xffffffff));
+    g.drawText(juce::String::charToString(cell.note),
+               (int)px, (int)py, (int)tileW, (int)tileH,
+               juce::Justification::centred);
+    // Fired cells get a white border, locked cells get a dimmer one
+    if (cell.fired) {
+        g.setColour(juce::Colour(0xffffffff));
+        g.drawRect(px, py, tileW, tileH, 1.0f);
+    } else if (cell.locked) {
+        g.setColour(juce::Colour(0x80ffffff));
+        g.drawRect(px, py, tileW, tileH, 1.0f);
+    }
+}
+
 void GridComponent::updateFontSize(float newSize) {
     fontSize = juce::jlimit(8.0f, 36.0f, newSize);
     monoFont = juce::Font(juce::FontOptions(juce::Font::getDefaultMonospacedFontName(), fontSize, juce::Font::plain));
@@ -196,22 +415,23 @@ void GridComponent::updateFontSize(float newSize) {
 }
 
 void GridComponent::resized() {
-    // Only grow the grid, never shrink (prevents losing content on resize)
     int viewW = juce::jmax(1, (int)(getWidth() / tileW));
     int viewH = juce::jmax(1, (int)((getHeight() - 32.0f) / tileH));
     viewW = juce::jmin(viewW, orca::kMaxGridW);
     viewH = juce::jmin(viewH, orca::kMaxGridH);
 
     auto& grid = processor.engine.grid;
+    // Grow Orca grid storage (never shrink — preserves off-screen content)
     int newW = juce::jmax(grid.w, viewW);
     int newH = juce::jmax(grid.h, viewH);
 
+    const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+
     if (newW != grid.w || newH != grid.h) {
-        // Grow grid, preserving all existing content
         char buf[orca::kMaxGridSize];
+        char newCells[orca::kMaxGridSize];
         memcpy(buf, grid.cells, grid.w * grid.h);
 
-        char newCells[orca::kMaxGridSize];
         for (int i = 0; i < newW * newH; i++) newCells[i] = '.';
         for (int y = 0; y < grid.h; y++) {
             for (int x = 0; x < grid.w; x++) {
@@ -220,11 +440,107 @@ void GridComponent::resized() {
         }
         processor.engine.load(newW, newH, newCells, grid.f);
     }
+
+    // Update Life grid wrap boundary to match visible area
+    if (processor.engine.lifeMode)
+        processor.engine.lifeGrid.setWrapSize(viewW, viewH);
 }
 
 void GridComponent::timerCallback() {
-    // Always refresh shadow buffer so UI reflects edits even when DAW is stopped
-    processor.engine.updateShadow();
+    // Snapshot all pending messages under lock, then process outside lock.
+    // This keeps the lock held for only a tiny memcpy, never during I/O.
+
+    char localCmds[OrcaProcessor::kMaxPendingCommands][OrcaProcessor::kMaxPendingCommandLen];
+    int localCmdCount = 0;
+
+    char localUdp[OrcaProcessor::kMaxPendingUdp][OrcaProcessor::kMaxPendingUdpLen];
+    int localUdpCount = 0;
+
+    OrcaProcessor::PendingOscMsg localOsc[OrcaProcessor::kMaxPendingOsc];
+    int localOscCount = 0;
+
+    // Also snapshot network config (protects juce::String from setStateInformation on background thread)
+    juce::String localUdpIP;
+    int localUdpPort = 0;
+    int localOscPort = 0;
+
+    {
+        const juce::SpinLock::ScopedLockType lock(processor.pendingLock);
+
+        localCmdCount = processor.pendingCommandCount;
+        for (int i = 0; i < localCmdCount; i++)
+            memcpy(localCmds[i], processor.pendingCommands[i], OrcaProcessor::kMaxPendingCommandLen);
+        processor.pendingCommandCount = 0;
+
+        localUdpCount = processor.pendingUdpCount;
+        for (int i = 0; i < localUdpCount; i++)
+            memcpy(localUdp[i], processor.pendingUdp[i], OrcaProcessor::kMaxPendingUdpLen);
+        processor.pendingUdpCount = 0;
+
+        localOscCount = processor.pendingOscCount;
+        for (int i = 0; i < localOscCount; i++)
+            localOsc[i] = processor.pendingOsc[i];
+        processor.pendingOscCount = 0;
+
+        localUdpIP = processor.udpTargetIP;
+        localUdpPort = processor.udpOutputPort;
+        localOscPort = processor.oscOutputPort;
+    }
+
+    // Process $ operator commands
+    for (int i = 0; i < localCmdCount; i++) {
+        commander.query = juce::String(localCmds[i]);
+        commander.trigger(processor, *this);
+    }
+
+    // Send UDP messages
+    if (localUdpCount > 0) {
+        DBG("UDP: sending " + juce::String(localUdpCount) + " message(s) to " + localUdpIP + ":" + juce::String(localUdpPort));
+        if (!processor.udpSocket)
+            processor.setupUdpSocket();
+        if (processor.udpSocket) {
+            for (int i = 0; i < localUdpCount; i++) {
+                int len = 0;
+                while (len < OrcaProcessor::kMaxPendingUdpLen && localUdp[i][len] != '\0') len++;
+                int sent = processor.udpSocket->write(localUdpIP, localUdpPort,
+                                            localUdp[i], len);
+                DBG("  UDP msg[" + juce::String(i) + "]: \"" + juce::String(localUdp[i]) + "\" len=" + juce::String(len) + " sent=" + juce::String(sent));
+            }
+        } else {
+            DBG("  UDP socket is null after setup attempt!");
+        }
+    }
+
+    // Send OSC messages — reconnect if port/IP changed
+    if (localOscCount > 0) {
+        DBG("OSC: sending " + juce::String(localOscCount) + " message(s) to " + localUdpIP + ":" + juce::String(localOscPort));
+        if (!processor.oscSender) {
+            processor.oscSender = std::make_unique<juce::OSCSender>();
+            if (!processor.oscSender->connect(localUdpIP, localOscPort))
+                DBG("OSC: Failed to connect to " + localUdpIP + ":" + juce::String(localOscPort));
+            else
+                DBG("OSC: Connected to " + localUdpIP + ":" + juce::String(localOscPort));
+        }
+        for (int i = 0; i < localOscCount; i++) {
+            auto& msg = localOsc[i];
+            juce::String path = "/" + juce::String::charToString(msg.path);
+            juce::OSCMessage oscMsg(path);
+            // Append each char as its base-36 value (matching original Orca)
+            for (int j = 0; j < msg.dataLen; j++) {
+                oscMsg.addInt32(orca::valueOf(msg.data[j]));
+            }
+            bool ok = processor.oscSender->send(oscMsg);
+            DBG("  OSC msg[" + juce::String(i) + "]: path=" + path + " values=" + juce::String(msg.dataLen) + " sent=" + juce::String(ok ? 1 : 0));
+        }
+    }
+
+    // Always refresh shadow buffer so UI reflects edits even when DAW is stopped.
+    // When transport is running, skip grid.parse() (step() already did it) and
+    // lock engineLock so we don't race with processBlock's engine.step().
+    {
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+        processor.engine.updateShadow(processor.transportRunning.load(std::memory_order_relaxed));
+    }
     repaint();
 }
 
@@ -233,6 +549,406 @@ bool GridComponent::keyPressed(const juce::KeyPress& key) {
     int code = key.getKeyCode();
     bool shift = key.getModifiers().isShiftDown();
     bool cmd = key.getModifiers().isCommandDown();
+    bool alt = key.getModifiers().isAltDown();
+
+    // ── Commander input intercept ──
+    if (commander.isActive) {
+        if (code == juce::KeyPress::returnKey) {
+            commander.trigger(processor, *this);
+            return true;
+        }
+        if (code == juce::KeyPress::escapeKey) {
+            commander.stop();
+            return true;
+        }
+
+        // Backspace: delete char before cursor
+        if (code == juce::KeyPress::backspaceKey) {
+            if (cmd) commander.killToStart(); // Cmd+Backspace: delete to start
+            else     commander.erase();
+            commander.preview(processor, *this);
+            return true;
+        }
+
+        // Delete: delete char after cursor
+        if (code == juce::KeyPress::deleteKey) {
+            commander.eraseForward();
+            commander.preview(processor, *this);
+            return true;
+        }
+
+        // Arrow keys: cursor movement
+        if (code == juce::KeyPress::leftKey) {
+            if (cmd)       commander.moveCursorHome();      // Cmd+Left: start
+            else if (alt)  commander.moveCursorWordLeft();   // Alt+Left: prev word
+            else           commander.moveCursorLeft();
+            return true;
+        }
+        if (code == juce::KeyPress::rightKey) {
+            if (cmd)       commander.moveCursorEnd();        // Cmd+Right: end
+            else if (alt)  commander.moveCursorWordRight();  // Alt+Right: next word
+            else           commander.moveCursorRight();
+            return true;
+        }
+        if (code == juce::KeyPress::homeKey) { commander.moveCursorHome(); return true; }
+        if (code == juce::KeyPress::endKey)  { commander.moveCursorEnd();  return true; }
+
+        // History
+        if (code == juce::KeyPress::upKey)   { commander.historyUp();   return true; }
+        if (code == juce::KeyPress::downKey) { commander.historyDown(); return true; }
+
+        // Cmd shortcuts
+        if (cmd) {
+            if (code == 'A' || code == 'a') {
+                // Cmd+A: select all (move cursor to end)
+                commander.selectAll();
+                return true;
+            }
+            if (code == 'C' || code == 'c') {
+                // Cmd+C: copy entire query
+                juce::SystemClipboard::copyTextToClipboard(commander.query);
+                return true;
+            }
+            if (code == 'V' || code == 'v') {
+                // Cmd+V: paste at cursor
+                auto clip = juce::SystemClipboard::getTextFromClipboard();
+                // Strip newlines — single line only
+                clip = clip.replaceCharacters("\r\n", "  ").trim();
+                if (clip.isNotEmpty()) {
+                    commander.insertAtCursor(clip);
+                    commander.preview(processor, *this);
+                }
+                return true;
+            }
+            if (code == 'X' || code == 'x') {
+                // Cmd+X: cut (copy + clear)
+                juce::SystemClipboard::copyTextToClipboard(commander.query);
+                commander.replaceQuery("");
+                commander.preview(processor, *this);
+                return true;
+            }
+            if (code == 'K' || code == 'k') {
+                // Cmd+K while commander is open: kill to end of line
+                commander.killToEnd();
+                commander.preview(processor, *this);
+                return true;
+            }
+            return true; // consume other Cmd combos
+        }
+
+        // Accumulate printable characters
+        auto ch = key.getTextCharacter();
+        if (ch != 0 && ch >= 32) {
+            commander.write(ch);
+            commander.preview(processor, *this);
+        }
+        return true; // consume all keys while commander is active
+    }
+
+    // Space bar: toggle standalone transport (play/pause) — only in standalone mode
+    if (code == juce::KeyPress::spaceKey && !cmd && !shift
+        && processor.wrapperType == OrcaProcessor::wrapperType_Standalone) {
+        bool wasOn = processor.standalonePlay.load(std::memory_order_relaxed);
+        processor.standalonePlay.store(!wasOn, std::memory_order_relaxed);
+        return true;
+    }
+
+    // Cmd+K: open commander
+    if (cmd && !shift && code == 'K') {
+        commander.start();
+        return true;
+    }
+
+    // Cmd+F: open commander with find:
+    if (cmd && !shift && code == 'F') {
+        commander.start("find:");
+        return true;
+    }
+
+    // Cmd+L: toggle Life mode
+    // Cmd+G: toggle Life (Game of Life) mode
+    if (cmd && !shift && code == 'G') {
+        auto& engine = processor.engine;
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+        if (engine.lifeMode) {
+            orca::MidiEvent events[orca::kMaxEvents];
+            int eventCount = 0;
+            engine.exitLifeMode(events, orca::kMaxEvents, eventCount);
+            for (int i = 0; i < eventCount; i++)
+                processor.pushLifeEvent(events[i]);
+        } else {
+            engine.enterLifeMode();
+        }
+        return true;
+    }
+
+    // Tab: cycle paint octave, Shift+Tab: cycle paint channel (Life mode)
+    if (code == juce::KeyPress::tabKey && !cmd) {
+        auto& engine = processor.engine;
+        if (engine.lifeMode) {
+            if (shift) {
+                engine.paintChannel = (engine.paintChannel + 1) % 16;
+            } else {
+                engine.paintOctave = engine.paintOctave + 1;
+                if (engine.paintOctave > engine.lifeGrid.maxOctave)
+                    engine.paintOctave = engine.lifeGrid.minOctave;
+            }
+            return true;
+        }
+    }
+
+    // Life mode: Cmd+R = reset to initial state
+    if (cmd && !shift && code == 'R') {
+        auto& engine = processor.engine;
+        if (engine.lifeMode && engine.lifeGrid.hasInitialState) {
+            const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+            orca::MidiEvent events[orca::kMaxEvents];
+            int count = engine.lifeGrid.resetToInitial(events, orca::kMaxEvents);
+            for (int i = 0; i < count; i++)
+                processor.pushLifeEvent(events[i]);
+            return true;
+        }
+    }
+
+    // Life mode: Cmd+Shift+R = save current state as new initial
+    if (cmd && shift && code == 'R') {
+        auto& engine = processor.engine;
+        if (engine.lifeMode) {
+            const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+            engine.lifeGrid.saveInitialState();
+            return true;
+        }
+    }
+
+    // Life mode: Cmd+Shift+S = cycle scale
+    if (cmd && shift && code == 'S') {
+        auto& engine = processor.engine;
+        if (engine.lifeMode) {
+            int s = (processor.lifeScaleParam->getIndex() + 1) % orca::LifeGrid::NumScales;
+            processor.lifeScaleParam->setValueNotifyingHost(
+                processor.lifeScaleParam->convertTo0to1(s));
+            return true;
+        }
+    }
+
+    // Life mode: Cmd+M = toggle pulse/hold mode
+    if (cmd && !shift && code == 'M') {
+        auto& engine = processor.engine;
+        if (engine.lifeMode) {
+            processor.lifePulseParam->setValueNotifyingHost(
+                processor.lifePulseParam->get() ? 0.0f : 1.0f);
+            return true;
+        }
+    }
+
+    // Life mode: Cmd+N = cycle root note (C, C#, D, ... B)
+    if (cmd && !shift && code == 'N') {
+        auto& engine = processor.engine;
+        if (engine.lifeMode) {
+            int r = (processor.lifeRootParam->getIndex() + 1) % 12;
+            processor.lifeRootParam->setValueNotifyingHost(
+                processor.lifeRootParam->convertTo0to1(r));
+            return true;
+        }
+    }
+
+    // Life mode: Cmd+Shift+K = toggle lock (protect) selected cells
+    if (cmd && shift && code == 'K') {
+        auto& engine = processor.engine;
+        if (engine.lifeMode) {
+            const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+            auto& lg = engine.lifeGrid;
+            pushLifeHistory();
+            for (int dy = 0; dy < selectH; dy++)
+                for (int dx = 0; dx < selectW; dx++) {
+                    int idx = lg.indexAt(cursorX + dx, cursorY + dy);
+                    if (idx >= 0 && lg.cells[idx].alive)
+                        lg.cells[idx].locked = !lg.cells[idx].locked;
+                }
+            return true;
+        }
+    }
+
+    // Life mode: Cmd+P / Cmd+Shift+P = enter/cycle stamp mode within category
+    if (cmd && code == 'P') {
+        auto& engine = processor.engine;
+        if (engine.lifeMode) {
+            if (!stampMode) {
+                stampMode = true;
+                stampCategory = 0;
+                stampIndex = stampCategories[0].start;
+            } else {
+                auto& cat = stampCategories[stampCategory];
+                int posInCat = stampIndex - cat.start;
+                if (shift)
+                    posInCat = (posInCat - 1 + cat.count) % cat.count;
+                else
+                    posInCat = (posInCat + 1) % cat.count;
+                stampIndex = cat.start + posInCat;
+            }
+            return true;
+        }
+    }
+
+    // Stamp mode: Cmd+] / Cmd+[ = cycle category
+    if (stampMode && cmd && (code == ']' || code == '[')) {
+        if (code == ']')
+            stampCategory = (stampCategory + 1) % numStampCategories;
+        else
+            stampCategory = (stampCategory - 1 + numStampCategories) % numStampCategories;
+        stampIndex = stampCategories[stampCategory].start;
+        return true;
+    }
+
+    // Stamp mode: Enter = place pattern
+    if (stampMode && code == juce::KeyPress::returnKey) {
+        auto& p = orca::builtInPatterns[stampIndex];
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+        auto& lg = processor.engine.lifeGrid;
+        pushLifeHistory();
+
+        for (int py = 0; py < p.h; py++) {
+            for (int px = 0; px < p.w; px++) {
+                int srcIdx = px + p.w * py;
+                char c = p.data[srcIdx];
+                int destIdx = lg.indexAt(cursorX + px, cursorY + py);
+                if (destIdx < 0) continue;
+
+                if (c == 'X') {
+                    int sLen = orca::LifeGrid::scaleLengths[static_cast<int>(lg.currentScale)];
+                    int deg = juce::Random::getSystemRandom().nextInt(sLen);
+                    int semi = orca::LifeGrid::scaleNotes[static_cast<int>(lg.currentScale)][deg];
+                    lg.cells[destIdx].alive = true;
+                    lg.cells[destIdx].note = orca::LifeGrid::semitoneToNote[semi];
+                    lg.cells[destIdx].channel = processor.engine.paintChannel;
+                    lg.cells[destIdx].octave = processor.engine.paintOctave;
+                    lg.cells[destIdx].locked = false;
+                }
+            }
+        }
+        selectW = 1;
+        selectH = 1;
+        stampMode = false;
+        return true;
+    }
+
+    // Stamp mode: Escape = cancel
+    if (stampMode && code == juce::KeyPress::escapeKey) {
+        stampMode = false;
+        return true;
+    }
+
+    // Life mode: Cmd+Shift+Up/Down = increase/decrease evolve rate
+    if (cmd && shift && processor.engine.lifeMode &&
+        (code == juce::KeyPress::upKey || code == juce::KeyPress::downKey)) {
+        auto& lg = processor.engine.lifeGrid;
+        if (code == juce::KeyPress::upKey)
+            lg.evolveRateUp();
+        else
+            lg.evolveRateDown();
+        return true;
+    }
+
+    // Life mode selection transforms (only when selection > 1x1)
+    if (cmd && processor.engine.lifeMode && (selectW > 1 || selectH > 1)) {
+        auto& lg = processor.engine.lifeGrid;
+
+        // Cmd+E: rotate selection 90° clockwise
+        if (code == 'E') {
+            pushLifeHistory();
+            orca::LifeCell temp[orca::kMaxGridSize];
+            for (int dy = 0; dy < selectH; dy++)
+                for (int dx = 0; dx < selectW; dx++) {
+                    int srcIdx = lg.indexAt(cursorX + dx, cursorY + dy);
+                    if (srcIdx >= 0)
+                        temp[dx + selectW * dy] = lg.cells[srcIdx];
+                    else
+                        temp[dx + selectW * dy] = orca::LifeCell();
+                }
+            // Rotated: new width = old height, new height = old width
+            int newW = selectH, newH = selectW;
+            for (int dy = 0; dy < newH; dy++)
+                for (int dx = 0; dx < newW; dx++) {
+                    int srcX = dy;
+                    int srcY = newW - 1 - dx;
+                    int dstIdx = lg.indexAt(cursorX + dx, cursorY + dy);
+                    if (dstIdx >= 0)
+                        lg.cells[dstIdx] = temp[srcX + selectW * srcY];
+                }
+            // Clear cells outside new bounds but inside old bounds
+            for (int dy = 0; dy < juce::jmax(selectH, newH); dy++)
+                for (int dx = 0; dx < juce::jmax(selectW, newW); dx++) {
+                    if (dx >= newW || dy >= newH) {
+                        int idx = lg.indexAt(cursorX + dx, cursorY + dy);
+                        if (idx >= 0 && dx < selectW && dy < selectH)
+                            lg.cells[idx] = orca::LifeCell();
+                    }
+                }
+            selectW = newW;
+            selectH = newH;
+            return true;
+        }
+
+        // Cmd+Shift+H: mirror horizontal (flip left-right)
+        if (code == 'H') {
+            pushLifeHistory();
+            for (int dy = 0; dy < selectH; dy++)
+                for (int dx = 0; dx < selectW / 2; dx++) {
+                    int leftIdx = lg.indexAt(cursorX + dx, cursorY + dy);
+                    int rightIdx = lg.indexAt(cursorX + selectW - 1 - dx, cursorY + dy);
+                    if (leftIdx >= 0 && rightIdx >= 0)
+                        std::swap(lg.cells[leftIdx], lg.cells[rightIdx]);
+                }
+            return true;
+        }
+
+        // Cmd+Shift+J: mirror vertical (flip up-down)
+        if (code == 'J') {
+            pushLifeHistory();
+            for (int dy = 0; dy < selectH / 2; dy++)
+                for (int dx = 0; dx < selectW; dx++) {
+                    int topIdx = lg.indexAt(cursorX + dx, cursorY + dy);
+                    int botIdx = lg.indexAt(cursorX + dx, cursorY + selectH - 1 - dy);
+                    if (topIdx >= 0 && botIdx >= 0)
+                        std::swap(lg.cells[topIdx], lg.cells[botIdx]);
+                }
+            return true;
+        }
+    }
+
+    // Life mode: Cmd+Up/Down = shift octave of selection
+    if (cmd && processor.engine.lifeMode &&
+        (code == juce::KeyPress::upKey || code == juce::KeyPress::downKey)) {
+        auto& lg = processor.engine.lifeGrid;
+        pushLifeHistory();
+        int delta = (code == juce::KeyPress::upKey) ? 1 : -1;
+        for (int dy = 0; dy < selectH; dy++)
+            for (int dx = 0; dx < selectW; dx++) {
+                int idx = lg.indexAt(cursorX + dx, cursorY + dy);
+                if (idx >= 0 && lg.cells[idx].alive) {
+                    int oct = lg.cells[idx].octave + delta;
+                    lg.cells[idx].octave = static_cast<uint8_t>(juce::jlimit(0, lg.maxOctave, oct));
+                }
+            }
+        return true;
+    }
+
+    // Life mode: Cmd+Left/Right = shift channel of selection
+    if (cmd && processor.engine.lifeMode &&
+        (code == juce::KeyPress::leftKey || code == juce::KeyPress::rightKey)) {
+        auto& lg = processor.engine.lifeGrid;
+        pushLifeHistory();
+        int delta = (code == juce::KeyPress::rightKey) ? 1 : -1;
+        for (int dy = 0; dy < selectH; dy++)
+            for (int dx = 0; dx < selectW; dx++) {
+                int idx = lg.indexAt(cursorX + dx, cursorY + dy);
+                if (idx >= 0 && lg.cells[idx].alive) {
+                    int ch = lg.cells[idx].channel + delta;
+                    lg.cells[idx].channel = static_cast<uint8_t>(juce::jlimit(0, 15, ch));
+                }
+            }
+        return true;
+    }
 
     // Cmd+S: save as
     if (cmd && code == 'S') {
@@ -240,74 +956,42 @@ bool GridComponent::keyPressed(const juce::KeyPress& key) {
         return true;
     }
 
-    // Cmd+G: set groove
-    if (cmd && code == 'G') {
-        auto* aw = new juce::AlertWindow("Set Groove",
-            "Enter groove ratios (semicolon-separated, 50=normal).\n"
-            "Example: 75;25 for swing, 50 for straight.",
-            juce::AlertWindow::NoIcon);
-        // Pre-fill with current groove
-        juce::String currentGroove;
-        for (int i = 0; i < processor.grooveLength; i++) {
-            if (i > 0) currentGroove += ";";
-            currentGroove += juce::String((int)(processor.grooves[i] * 50.0));
-        }
-        aw->addTextEditor("groove", currentGroove, "Groove values:");
-        aw->addButton("OK", 1);
-        aw->addButton("Cancel", 0);
-        aw->enterModalState(true, juce::ModalCallbackFunction::create(
-            [this, aw](int result) {
-                if (result == 1) {
-                    auto text = aw->getTextEditorContents("groove");
-                    auto parts = juce::StringArray::fromTokens(text, ";", "");
-                    if (parts.size() > 0) {
-                        double ratios[OrcaProcessor::kMaxGrooveSlots];
-                        double sum = 0.0;
-                        int count = juce::jmin(parts.size(), (int)OrcaProcessor::kMaxGrooveSlots - 1);
-                        for (int i = 0; i < count; i++) {
-                            int v = parts[i].getIntValue();
-                            if (v == 0) v = 50;
-                            ratios[i] = v / 50.0;
-                            sum += ratios[i];
-                        }
-                        // Append closing ratio so the cycle averages to 1.0
-                        ratios[count] = (count + 1) - sum;
-                        count++;
-                        processor.setGroove(ratios, count);
-
-                        // Sync the DAW shuffle slider to match (centered: 100=straight)
-                        // swing = (pct-100)/100 * 0.98, so pct = swing/0.98 * 100 + 100
-                        if (count == 3) {
-                            double swing = ratios[0] - 1.0; // positive = swing, negative = inverse
-                            float pct = (float)(swing / 0.98 * 100.0 + 100.0);
-                            pct = juce::jlimit(0.0f, 200.0f, pct);
-                            processor.shuffleParam->setValueNotifyingHost(
-                                processor.shuffleParam->getNormalisableRange().convertTo0to1(pct));
-                            processor.lastShuffleValue = pct;
-                        } else {
-                            // Reset to center (straight)
-                            float center = 100.0f;
-                            processor.shuffleParam->setValueNotifyingHost(
-                                processor.shuffleParam->getNormalisableRange().convertTo0to1(center));
-                            processor.lastShuffleValue = center;
-                        }
-                    }
+    // Cmd+L: import modules (load .orca files into inject cache)
+    if (cmd && !shift && code == 'L') {
+        fileChooser = std::make_unique<juce::FileChooser>(
+            "Import modules", currentFile.existsAsFile() ? currentFile.getParentDirectory() : juce::File(),
+            "*.orca;*.life");
+        fileChooser->launchAsync(
+            juce::FileBrowserComponent::openMode
+            | juce::FileBrowserComponent::canSelectFiles
+            | juce::FileBrowserComponent::canSelectMultipleItems,
+            [this](const juce::FileChooser& fc) {
+                auto results = fc.getResults();
+                for (auto& f : results) {
+                    if (!f.existsAsFile()) continue;
+                    auto name = f.getFileName();
+                    auto content = f.loadFileAsString();
+                    if (content.isNotEmpty())
+                        injectCache[name] = content;
                 }
-                delete aw;
-            }), true);
+            });
         return true;
     }
 
-    // Cmd+O: open .orca file
+    // Cmd+O: open .orca or .life file
     if (cmd && code == 'O') {
         fileChooser = std::make_unique<juce::FileChooser>(
-            "Open .orca file", juce::File(), "*");
+            "Open file", juce::File(), "*.orca;*.life");
         fileChooser->launchAsync(juce::FileBrowserComponent::openMode
                                  | juce::FileBrowserComponent::canSelectFiles,
             [this](const juce::FileChooser& fc) {
                 auto result = fc.getResult();
-                if (result.existsAsFile() && result.hasFileExtension("orca"))
-                    loadOrcaFile(result);
+                if (result.existsAsFile()) {
+                    if (result.hasFileExtension("orca"))
+                        loadOrcaFile(result);
+                    else if (result.hasFileExtension("life"))
+                        loadLifeFile(result);
+                }
             });
         return true;
     }
@@ -336,40 +1020,79 @@ bool GridComponent::keyPressed(const juce::KeyPress& key) {
 
     // Cmd+Z: undo, Cmd+Shift+Z: redo
     if (cmd && code == 'Z') {
-        if (shift) redo(); else undo();
+        if (processor.engine.lifeMode) {
+            if (shift) redoLife(); else undoLife();
+        } else {
+            if (shift) redo(); else undo();
+        }
         return true;
     }
 
     // Cmd+C: copy
     if (cmd && code == 'C') {
+        auto& engine = processor.engine;
         clipW = selectW;
         clipH = selectH;
-        for (int y = 0; y < clipH; y++)
-            for (int x = 0; x < clipW; x++)
-                clipboard[x + clipW * y] = grid.glyphAt(cursorX + x, cursorY + y);
+        if (engine.lifeMode) {
+            for (int dy = 0; dy < clipH; dy++)
+                for (int dx = 0; dx < clipW; dx++) {
+                    int idx = engine.lifeGrid.indexAt(cursorX + dx, cursorY + dy);
+                    lifeClipboard[dx + clipW * dy] = (idx >= 0) ? engine.lifeGrid.cells[idx] : orca::LifeCell();
+                }
+        } else {
+            for (int y = 0; y < clipH; y++)
+                for (int x = 0; x < clipW; x++)
+                    clipboard[x + clipW * y] = grid.glyphAt(cursorX + x, cursorY + y);
+        }
         return true;
     }
 
     // Cmd+X: cut
     if (cmd && code == 'X') {
-        pushHistory();
+        auto& engine = processor.engine;
         clipW = selectW;
         clipH = selectH;
-        for (int y = 0; y < clipH; y++)
-            for (int x = 0; x < clipW; x++) {
-                clipboard[x + clipW * y] = grid.glyphAt(cursorX + x, cursorY + y);
-                grid.write(cursorX + x, cursorY + y, '.');
-            }
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+        if (engine.lifeMode) {
+            pushLifeHistory();
+            for (int dy = 0; dy < clipH; dy++)
+                for (int dx = 0; dx < clipW; dx++) {
+                    int idx = engine.lifeGrid.indexAt(cursorX + dx, cursorY + dy);
+                    if (idx >= 0) {
+                        lifeClipboard[dx + clipW * dy] = engine.lifeGrid.cells[idx];
+                        engine.lifeGrid.cells[idx] = orca::LifeCell();
+                    }
+                }
+        } else {
+            pushHistory();
+            for (int y = 0; y < clipH; y++)
+                for (int x = 0; x < clipW; x++) {
+                    clipboard[x + clipW * y] = grid.glyphAt(cursorX + x, cursorY + y);
+                    grid.write(cursorX + x, cursorY + y, '.');
+                }
+        }
         return true;
     }
 
     // Cmd+V: paste
     if (cmd && code == 'V') {
+        auto& engine = processor.engine;
         if (clipW > 0 && clipH > 0) {
-            pushHistory();
-            for (int y = 0; y < clipH; y++)
-                for (int x = 0; x < clipW; x++)
-                    grid.write(cursorX + x, cursorY + y, clipboard[x + clipW * y]);
+            const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+            if (engine.lifeMode) {
+                pushLifeHistory();
+                for (int dy = 0; dy < clipH; dy++)
+                    for (int dx = 0; dx < clipW; dx++) {
+                        int idx = engine.lifeGrid.indexAt(cursorX + dx, cursorY + dy);
+                        if (idx >= 0)
+                            engine.lifeGrid.cells[idx] = lifeClipboard[dx + clipW * dy];
+                    }
+            } else {
+                pushHistory();
+                for (int y = 0; y < clipH; y++)
+                    for (int x = 0; x < clipW; x++)
+                        grid.write(cursorX + x, cursorY + y, clipboard[x + clipW * y]);
+            }
         }
         return true;
     }
@@ -410,21 +1133,66 @@ bool GridComponent::keyPressed(const juce::KeyPress& key) {
 
     // Backspace/Delete: erase selection
     if (code == juce::KeyPress::backspaceKey || code == juce::KeyPress::deleteKey) {
-        pushHistory();
-        for (int y = 0; y < selectH; y++)
-            for (int x = 0; x < selectW; x++)
-                grid.write(cursorX + x, cursorY + y, '.');
+        auto& engine = processor.engine;
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+        if (engine.lifeMode) {
+            pushLifeHistory();
+            for (int dy = 0; dy < selectH; dy++)
+                for (int dx = 0; dx < selectW; dx++) {
+                    int idx = engine.lifeGrid.indexAt(cursorX + dx, cursorY + dy);
+                    if (idx >= 0) {
+                        engine.lifeGrid.cells[idx] = orca::LifeCell();
+                    }
+                }
+        } else {
+            pushHistory();
+            for (int y = 0; y < selectH; y++)
+                for (int x = 0; x < selectW; x++)
+                    grid.write(cursorX + x, cursorY + y, '.');
+        }
         return true;
     }
 
-    // Printable character: write glyph (cursor stays in place, like original Orca)
+    // Printable character input
     auto textChar = key.getTextCharacter();
+    auto& engine = processor.engine;
+    if (engine.lifeMode) {
+        // Life mode: only accept note letters (A-G, a-g) and '.'
+        char ch = static_cast<char>(textChar);
+        if (ch == '.') {
+            const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+            pushLifeHistory();
+            int idx = engine.lifeGrid.indexAt(cursorX, cursorY);
+            if (idx >= 0)
+                engine.lifeGrid.cells[idx] = orca::LifeCell();
+            return true;
+        }
+        // Accept A-G and a-g as notes
+        char lower = (ch >= 'A' && ch <= 'Z') ? (ch - 'A' + 'a') : ch;
+        if (lower >= 'a' && lower <= 'g') {
+            const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+            pushLifeHistory();
+            int idx = engine.lifeGrid.indexAt(cursorX, cursorY);
+            if (idx >= 0) {
+                engine.lifeGrid.cells[idx].note = ch;
+                engine.lifeGrid.cells[idx].channel = engine.paintChannel;
+                engine.lifeGrid.cells[idx].octave = engine.paintOctave;
+                engine.lifeGrid.cells[idx].alive = true;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    // Normal Orca mode character input
     if (textChar == '.') {
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
         pushHistory();
         grid.write(cursorX, cursorY, '.');
         return true;
     }
     if (textChar != 0 && orca::isOperatorGlyph(static_cast<char>(textChar))) {
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
         pushHistory();
         grid.write(cursorX, cursorY, static_cast<char>(textChar));
         return true;
@@ -483,29 +1251,77 @@ void GridComponent::pushHistory() {
 }
 
 void GridComponent::undo() {
-    if (historyPos <= 0) return;
-    historyPos--;
+    if (historyPos < 0 || historyCount == 0) return;
     auto& snap = history[historyPos];
-    processor.engine.load(snap.w, snap.h, snap.cells, processor.engine.grid.f);
+    {
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+        processor.engine.load(snap.w, snap.h, snap.cells, processor.engine.grid.f);
+    }
+    historyPos--;
 }
 
 void GridComponent::redo() {
-    if (historyPos >= historyCount - 1) return;
+    if (historyPos + 1 >= historyCount) return;
     historyPos++;
     auto& snap = history[historyPos];
+    const juce::SpinLock::ScopedLockType lock(processor.engineLock);
     processor.engine.load(snap.w, snap.h, snap.cells, processor.engine.grid.f);
+}
+
+void GridComponent::pushLifeHistory() {
+    if (!lifeHistory)
+        lifeHistory = new LifeSnapshot[kMaxLifeHistory];
+
+    if (lifeHistoryPos < lifeHistoryCount - 1)
+        lifeHistoryCount = lifeHistoryPos + 1;
+
+    if (lifeHistoryCount >= kMaxLifeHistory) {
+        for (int i = 0; i < kMaxLifeHistory - 1; i++)
+            lifeHistory[i] = lifeHistory[i + 1];
+        lifeHistoryCount = kMaxLifeHistory - 1;
+    }
+
+    auto& snap = lifeHistory[lifeHistoryCount];
+    auto& lg = processor.engine.lifeGrid;
+    memcpy(snap.cells, lg.cells, sizeof(orca::LifeCell) * lg.w * lg.h);
+    snap.w = lg.w;
+    snap.h = lg.h;
+    lifeHistoryCount++;
+    lifeHistoryPos = lifeHistoryCount - 1;
+}
+
+void GridComponent::undoLife() {
+    if (!lifeHistory || lifeHistoryPos < 0 || lifeHistoryCount == 0) return;
+    auto& snap = lifeHistory[lifeHistoryPos];
+    lifeHistoryPos--;
+    const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+    auto& lg = processor.engine.lifeGrid;
+    memcpy(lg.cells, snap.cells, sizeof(orca::LifeCell) * snap.w * snap.h);
+}
+
+void GridComponent::redoLife() {
+    if (!lifeHistory || lifeHistoryPos + 1 >= lifeHistoryCount) return;
+    lifeHistoryPos++;
+    auto& snap = lifeHistory[lifeHistoryPos];
+    const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+    auto& lg = processor.engine.lifeGrid;
+    memcpy(lg.cells, snap.cells, sizeof(orca::LifeCell) * snap.w * snap.h);
 }
 
 // ── File loading ──
 
 bool GridComponent::isInterestedInFileDrag(const juce::StringArray& files) {
     for (auto& f : files)
-        if (f.endsWith(".orca")) return true;
+        if (f.endsWith(".orca") || f.endsWith(".life")) return true;
     return false;
 }
 
 void GridComponent::filesDropped(const juce::StringArray& files, int /*x*/, int /*y*/) {
     for (auto& f : files) {
+        if (f.endsWith(".life")) {
+            loadLifeFile(juce::File(f));
+            break;
+        }
         if (f.endsWith(".orca")) {
             loadOrcaFile(juce::File(f));
             break;
@@ -547,7 +1363,10 @@ void GridComponent::loadOrcaFile(const juce::File& file) {
         }
     }
 
-    processor.engine.load(w, h, buf, 0);
+    {
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+        processor.engine.load(w, h, buf, 0);
+    }
     currentFile = file;
 
     // Resize window to fit
@@ -569,15 +1388,750 @@ void GridComponent::saveOrcaFile(const juce::File& file) {
 }
 
 void GridComponent::saveAs() {
+    bool isLife = processor.engine.lifeMode;
+    auto ext = isLife ? "*.life" : "*.orca";
+    auto title = isLife ? "Save .life file" : "Save .orca file";
     fileChooser = std::make_unique<juce::FileChooser>(
-        "Save .orca file", currentFile.existsAsFile() ? currentFile : juce::File(), "*.orca");
+        title, currentFile.existsAsFile() ? currentFile : juce::File(), ext);
     fileChooser->launchAsync(juce::FileBrowserComponent::saveMode
                              | juce::FileBrowserComponent::canSelectFiles,
-        [this](const juce::FileChooser& fc) {
+        [this, isLife](const juce::FileChooser& fc) {
             auto result = fc.getResult();
-            if (result != juce::File())
-                saveOrcaFile(result.withFileExtension("orca"));
+            if (result != juce::File()) {
+                if (isLife)
+                    saveLifeFile(result.withFileExtension("life"));
+                else
+                    saveOrcaFile(result.withFileExtension("orca"));
+            }
         });
+}
+
+// ── Save/Load .life files ──
+
+void GridComponent::saveLifeFile(const juce::File& file) {
+    auto& lg = processor.engine.lifeGrid;
+    juce::String content;
+
+    // Header line: dimensions and settings
+    content << "LIFE " << lg.w << " " << lg.h
+            << " scale:" << (int)lg.currentScale
+            << " root:" << lg.rootNote
+            << " rate:" << lg.evolveRate
+            << " pulse:" << (lg.pulseMode ? 1 : 0)
+            << " decay:" << (lg.decay ? 1 : 0)
+            << " minvel:" << (int)lg.minVelocity
+            << " minprob:" << lg.minProb
+            << " maxnotes:" << lg.maxNotes
+            << " seq:" << static_cast<int>(lg.seqMode)
+            << " lockoct:" << (lg.lockOctave ? 1 : 0)
+            << " chord:" << lg.chordDegreesString()
+            << " dedup:" << (lg.dedup ? 1 : 0)
+            << " dedupcc:" << lg.dedupCC
+            << " minoct:" << lg.minOctave
+            << " maxoct:" << lg.maxOctave
+            << " rule:" << lg.ruleString
+            << "\n";
+
+    // Grid: one row per line
+    // Alive cells: note + channel(hex) + octave + flags, e.g. "C03." or "C03!" (locked)
+    // Dead cells: "...."
+    for (int y = 0; y < lg.h; y++) {
+        for (int x = 0; x < lg.w; x++) {
+            int idx = lg.indexAt(x, y);
+            auto& cell = lg.cells[idx];
+            if (cell.alive) {
+                char ch = (cell.channel < 10) ? ('0' + cell.channel) : ('a' + cell.channel - 10);
+                char flags = cell.locked ? '!' : '.';
+                content << cell.note << ch << (char)('0' + cell.octave) << flags;
+            } else {
+                content << "....";
+            }
+        }
+        content << "\n";
+    }
+
+    file.replaceWithText(content);
+    currentFile = file;
+}
+
+void GridComponent::loadLifeFile(const juce::File& file) {
+    auto content = file.loadFileAsString();
+    if (content.isEmpty()) return;
+
+    auto lines = juce::StringArray::fromLines(content);
+    if (lines.isEmpty() || !lines[0].startsWith("LIFE ")) return;
+
+    // Parse header
+    auto header = lines[0];
+    auto tokens = juce::StringArray::fromTokens(header, " ", "");
+    if (tokens.size() < 3) return;
+
+    int w = tokens[1].getIntValue();
+    int h = tokens[2].getIntValue();
+    w = juce::jlimit(1, orca::kMaxGridW, w);
+    h = juce::jlimit(1, orca::kMaxGridH, h);
+
+    // Parse optional settings from header
+    int scale = 0, root = 0, rate = 4, pulse = 0, decayVal = 0, minvel = 40, minprob = 10, maxnotes = 0, seqVal = 0, lockoct = 0, dedupVal = 0, dedupcc = -1, minoct = 0, maxoct = 7;
+    juce::String chordStr = "off";
+    juce::String ruleStr = "23/3";
+    for (int i = 3; i < tokens.size(); i++) {
+        if (tokens[i].startsWith("scale:")) scale = tokens[i].substring(6).getIntValue();
+        else if (tokens[i].startsWith("root:")) root = tokens[i].substring(5).getIntValue();
+        else if (tokens[i].startsWith("rate:")) rate = tokens[i].substring(5).getIntValue();
+        else if (tokens[i].startsWith("pulse:")) pulse = tokens[i].substring(6).getIntValue();
+        else if (tokens[i].startsWith("decay:")) decayVal = tokens[i].substring(6).getIntValue();
+        else if (tokens[i].startsWith("minvel:")) minvel = tokens[i].substring(7).getIntValue();
+        else if (tokens[i].startsWith("minprob:")) minprob = tokens[i].substring(8).getIntValue();
+        else if (tokens[i].startsWith("maxnotes:")) maxnotes = tokens[i].substring(9).getIntValue();
+        else if (tokens[i].startsWith("seq:")) seqVal = tokens[i].substring(4).getIntValue();
+        else if (tokens[i].startsWith("lockoct:")) lockoct = tokens[i].substring(8).getIntValue();
+        else if (tokens[i].startsWith("chord:")) chordStr = tokens[i].substring(6);
+        else if (tokens[i].startsWith("dedup:")) dedupVal = tokens[i].substring(6).getIntValue();
+        else if (tokens[i].startsWith("dedupcc:")) dedupcc = tokens[i].substring(8).getIntValue();
+        else if (tokens[i].startsWith("minoct:")) minoct = tokens[i].substring(7).getIntValue();
+        else if (tokens[i].startsWith("maxoct:")) maxoct = tokens[i].substring(7).getIntValue();
+        else if (tokens[i].startsWith("rule:")) ruleStr = tokens[i].substring(5);
+    }
+
+    // Enter Life mode with correct grid size (lock protects engine state from audio thread)
+    {
+    const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+    processor.engine.grid.reset(w, h);
+    if (!processor.engine.lifeMode)
+        processor.engine.enterLifeMode();
+    auto& lg = processor.engine.lifeGrid;
+    lg.resize(w, h);
+    // Set APVTS params (will be synced to lifeGrid in processBlock)
+    processor.lifeScaleParam->setValueNotifyingHost(
+        processor.lifeScaleParam->convertTo0to1(juce::jlimit(0, (int)orca::LifeGrid::NumScales - 1, scale)));
+    processor.lifeRootParam->setValueNotifyingHost(
+        processor.lifeRootParam->convertTo0to1(juce::jlimit(0, 11, root)));
+    processor.lifeRateParam->setValueNotifyingHost(
+        processor.lifeRateParam->convertTo0to1(juce::jlimit(1, 32, rate)));
+    processor.lifePulseParam->setValueNotifyingHost(pulse != 0 ? 1.0f : 0.0f);
+    processor.lifeDecayParam->setValueNotifyingHost(decayVal != 0 ? 1.0f : 0.0f);
+    processor.lifeMinVelParam->setValueNotifyingHost(
+        processor.lifeMinVelParam->convertTo0to1(juce::jlimit(1, 127, minvel)));
+    processor.lifeMinProbParam->setValueNotifyingHost(
+        processor.lifeMinProbParam->convertTo0to1(juce::jlimit(1, 100, minprob)));
+    processor.lifeMaxNotesParam->setValueNotifyingHost(
+        processor.lifeMaxNotesParam->convertTo0to1(juce::jmax(0, maxnotes)));
+    processor.lifeSeqParam->setValueNotifyingHost(
+        processor.lifeSeqParam->convertTo0to1(juce::jlimit(0, 4, seqVal)));
+    processor.lifeLockOctParam->setValueNotifyingHost(lockoct != 0 ? 1.0f : 0.0f);
+    {
+        int chordIdx = processor.findChordPresetIndex(chordStr);
+        processor.lifeChordParam->setValueNotifyingHost(
+            processor.lifeChordParam->convertTo0to1(chordIdx));
+        // Also set custom chord degrees directly if not a preset
+        if (chordIdx == 0 && chordStr != "off" && chordStr.isNotEmpty())
+            lg.setChordDegrees(chordStr.toRawUTF8());
+    }
+    processor.lifeDedupParam->setValueNotifyingHost(dedupVal != 0 ? 1.0f : 0.0f);
+    processor.lifeDedupCCParam->setValueNotifyingHost(
+        processor.lifeDedupCCParam->convertTo0to1(juce::jlimit(-1, 127, dedupcc)));
+    processor.lifeMinOctParam->setValueNotifyingHost(
+        processor.lifeMinOctParam->convertTo0to1(juce::jlimit(0, 8, minoct)));
+    processor.lifeMaxOctParam->setValueNotifyingHost(
+        processor.lifeMaxOctParam->convertTo0to1(juce::jlimit(0, 8, maxoct)));
+    // Rule: custom S/B notation goes directly, named presets go through APVTS
+    if (ruleStr.containsChar('/'))
+        lg.setRuleFromString(ruleStr.toRawUTF8());
+    else {
+        for (int i = 0; i < OrcaProcessor::numRulePresets; i++) {
+            if (ruleStr.equalsIgnoreCase(OrcaProcessor::rulePresets[i])) {
+                processor.lifeRuleParam->setValueNotifyingHost(
+                    processor.lifeRuleParam->convertTo0to1(i));
+                break;
+            }
+        }
+    }
+
+    // Parse cell rows (lines 1..h)
+    for (int y = 0; y < h && y + 1 < lines.size(); y++) {
+        auto& line = lines[y + 1];
+        // Each cell is 4 chars wide: note + channel(hex) + octave + flags
+        for (int x = 0; x < w; x++) {
+            int pos = x * 4;
+            if (pos + 3 >= line.length()) break;
+
+            char noteChar = static_cast<char>(line[pos]);
+            char chChar = static_cast<char>(line[pos + 1]);
+            char octChar = static_cast<char>(line[pos + 2]);
+            char flagChar = static_cast<char>(line[pos + 3]);
+
+            if (noteChar == '.') continue; // dead cell
+
+            int idx = lg.indexAt(x, y);
+            if (idx < 0) continue;
+
+            lg.cells[idx].note = noteChar;
+            lg.cells[idx].channel = static_cast<uint8_t>(
+                (chChar >= 'a') ? (chChar - 'a' + 10) : (chChar - '0'));
+            lg.cells[idx].octave = static_cast<uint8_t>(octChar - '0');
+            lg.cells[idx].alive = true;
+            lg.cells[idx].locked = (flagChar == '!');
+        }
+    }
+
+    processor.engine.updateShadow();
+    } // engineLock scope
+    currentFile = file;
+
+    // Resize window to fit
+    if (auto* editor = findParentComponentOfClass<OrcaEditor>()) {
+        int newWidth = (int)(w * tileW) + 4;
+        int newHeight = (int)(h * tileH) + 24;
+        editor->setSize(juce::jmax(400, newWidth), juce::jmax(300, newHeight));
+    }
+}
+
+// ── Inject block ──
+
+void GridComponent::injectBlock(const juce::String& content, int atX, int atY) {
+    if (content.isEmpty()) return;
+
+    auto& engine = processor.engine;
+    const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+
+    if (engine.lifeMode) {
+        // Life mode: parse .life format
+        auto lines = juce::StringArray::fromLines(content);
+        if (lines.isEmpty()) return;
+
+        // Check if it's a .life file (has LIFE header)
+        if (lines[0].startsWith("LIFE ")) {
+            pushLifeHistory();
+            auto& lg = engine.lifeGrid;
+            auto tokens = juce::StringArray::fromTokens(lines[0], " ", "");
+            int fw = (tokens.size() >= 2) ? tokens[1].getIntValue() : 0;
+
+            for (int y = 0; y + 1 < lines.size(); y++) {
+                auto& line = lines[y + 1];
+                for (int x = 0; x < fw; x++) {
+                    int pos = x * 4; // 4 chars per cell: note+channel+octave+flags
+                    if (pos + 3 >= line.length()) break;
+
+                    char noteChar = static_cast<char>(line[pos]);
+                    if (noteChar == '.') continue; // skip dead cells
+
+                    int idx = lg.indexAt(atX + x, atY + y);
+                    if (idx < 0) continue;
+
+                    char chChar = static_cast<char>(line[pos + 1]);
+                    char octChar = static_cast<char>(line[pos + 2]);
+                    char flags = static_cast<char>(line[pos + 3]);
+                    lg.cells[idx].note = noteChar;
+                    lg.cells[idx].channel = static_cast<uint8_t>(
+                        (chChar >= 'a') ? (chChar - 'a' + 10) : (chChar - '0'));
+                    lg.cells[idx].octave = static_cast<uint8_t>(octChar - '0');
+                    lg.cells[idx].alive = true;
+                    lg.cells[idx].locked = (flags == '!');
+                }
+            }
+        }
+    } else {
+        // Orca mode: parse as plain text grid
+        pushHistory();
+        auto& grid = engine.grid;
+        auto lines = juce::StringArray::fromLines(content);
+
+        // Remove trailing empty lines
+        while (lines.size() > 0 && lines[lines.size() - 1].trimEnd().isEmpty())
+            lines.remove(lines.size() - 1);
+
+        for (int y = 0; y < lines.size(); y++) {
+            auto& line = lines[y];
+            for (int x = 0; x < line.length(); x++) {
+                char c = static_cast<char>(line[x]);
+                grid.write(atX + x, atY + y, c);
+            }
+        }
+    }
+
+    engine.updateShadow();
+}
+
+// ── Commander ──
+
+bool Commander::trigger(OrcaProcessor& processor, GridComponent& editor) {
+    auto cmd = parse();
+    pushToHistory(query);
+
+    auto& engine = processor.engine;
+    auto& grid = engine.grid;
+    bool isLife = engine.lifeMode;
+    bool handled = true;
+
+    // ── Universal commands ──
+
+    if (cmd.name == "find") {
+        // Find text in grid and move cursor to first match
+        if (cmd.value.isNotEmpty()) {
+            auto target = cmd.value;
+            int len = target.length();
+            int gw = isLife ? engine.lifeGrid.w : grid.w;
+            int gh = isLife ? engine.lifeGrid.h : grid.h;
+            for (int y = 0; y < gh; y++) {
+                for (int x = 0; x <= gw - len; x++) {
+                    bool match = true;
+                    for (int i = 0; i < len && match; i++) {
+                        char gc;
+                        if (isLife) {
+                            int idx = engine.lifeGrid.indexAt(x + i, y);
+                            gc = (idx >= 0 && engine.lifeGrid.cells[idx].alive)
+                                 ? engine.lifeGrid.cells[idx].note : '.';
+                        } else {
+                            gc = grid.glyphAt(x + i, y);
+                        }
+                        if (gc != (char)target[i]) match = false;
+                    }
+                    if (match) {
+                        editor.cursorX = x;
+                        editor.cursorY = y;
+                        editor.selectW = len;
+                        editor.selectH = 1;
+                        stop();
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    else if (cmd.name == "select") {
+        // select:x;y or select:x;y;w;h
+        if (cmd.parts.size() >= 2) {
+            editor.cursorX = cmd.parts[0].getIntValue();
+            editor.cursorY = cmd.parts[1].getIntValue();
+            if (cmd.parts.size() >= 4) {
+                editor.selectW = juce::jmax(1, cmd.parts[2].getIntValue());
+                editor.selectH = juce::jmax(1, cmd.parts[3].getIntValue());
+            }
+        }
+    }
+    else if (cmd.name == "write") {
+        // write:text or write:text;x;y
+        if (cmd.value.isNotEmpty()) {
+            juce::String text = cmd.parts[0];
+            int wx = (cmd.parts.size() >= 2) ? cmd.parts[1].getIntValue() : editor.cursorX;
+            int wy = (cmd.parts.size() >= 3) ? cmd.parts[2].getIntValue() : editor.cursorY;
+            if (!isLife) {
+                const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+                for (int i = 0; i < text.length(); i++)
+                    grid.write(wx + i, wy, (char)text[i]);
+            }
+        }
+    }
+    else if (cmd.name == "groove") {
+        // groove:75;25 or groove:50 (reset)
+        if (cmd.parts.size() >= 1) {
+            double newGrooves[OrcaProcessor::kMaxGrooveSlots];
+            int newLen = juce::jmin(cmd.parts.size(), (int)OrcaProcessor::kMaxGrooveSlots);
+            double total = 0;
+            for (int i = 0; i < newLen; i++) {
+                newGrooves[i] = cmd.parts[i].getDoubleValue() / 50.0;
+                total += newGrooves[i];
+            }
+            // Auto-append balancing ratio
+            if (newLen < OrcaProcessor::kMaxGrooveSlots) {
+                double avg = (double)(newLen + 1);
+                double balance = avg - total;
+                if (balance > 0.01) {
+                    newGrooves[newLen] = balance;
+                    newLen++;
+                }
+            }
+            {
+                const juce::SpinLock::ScopedLockType lock(processor.pendingLock);
+                for (int i = 0; i < newLen; i++)
+                    processor.grooves[i] = newGrooves[i];
+                processor.grooveLength = newLen;
+                processor.grooveIndex = 0;
+            }
+        }
+    }
+    else if (cmd.name == "cc") {
+        // cc:N — set CC offset
+        if (cmd.value.isNotEmpty())
+            engine.io.cc.setOffset(cmd.value.getIntValue());
+    }
+    else if (cmd.name == "pg") {
+        // pg:channel;msb;lsb;program — MIDI program change with optional bank select
+        // msb and lsb can be blank for simple program change: pg:0;;;63
+        if (cmd.parts.size() >= 4) {
+            int ch = juce::jlimit(0, 15, cmd.parts[0].getIntValue());
+            int pgm = juce::jlimit(0, 127, cmd.parts[3].getIntValue());
+            auto msbStr = cmd.parts[1].trim();
+            auto lsbStr = cmd.parts[2].trim();
+
+            // Bank Select MSB (CC #0) — only if specified
+            if (msbStr.isNotEmpty()) {
+                orca::MidiEvent e;
+                e.bytes[0] = static_cast<uint8_t>(0xB0 | ch);
+                e.bytes[1] = 0x00; // CC #0 = Bank Select MSB
+                e.bytes[2] = static_cast<uint8_t>(juce::jlimit(0, 127, msbStr.getIntValue()));
+                e.numBytes = 3;
+                processor.pushLifeEvent(e);
+            }
+
+            // Bank Select LSB (CC #32) — only if specified
+            if (lsbStr.isNotEmpty()) {
+                orca::MidiEvent e;
+                e.bytes[0] = static_cast<uint8_t>(0xB0 | ch);
+                e.bytes[1] = 0x20; // CC #32 = Bank Select LSB
+                e.bytes[2] = static_cast<uint8_t>(juce::jlimit(0, 127, lsbStr.getIntValue()));
+                e.numBytes = 3;
+                processor.pushLifeEvent(e);
+            }
+
+            // Program Change
+            orca::MidiEvent e;
+            e.bytes[0] = static_cast<uint8_t>(0xC0 | ch);
+            e.bytes[1] = static_cast<uint8_t>(pgm);
+            e.numBytes = 2;
+            processor.pushLifeEvent(e);
+        }
+    }
+    else if (cmd.name == "udp") {
+        // udp:port — set UDP output port
+        if (cmd.value.isNotEmpty()) {
+            int port = cmd.value.getIntValue();
+            if (port >= 1000 && port <= 65535) {
+                {
+                    const juce::SpinLock::ScopedLockType lock(processor.pendingLock);
+                    processor.udpOutputPort = port;
+                }
+                processor.udpSocket.reset();
+            }
+        }
+    }
+    else if (cmd.name == "osc") {
+        // osc:port — set OSC output port (supports presets)
+        if (cmd.value.isNotEmpty()) {
+            auto val = cmd.value.toLowerCase().trim();
+            int port = 0;
+            if (val == "tidal" || val == "tidalcycles") port = 6010;
+            else if (val == "sonic" || val == "sonicpi") port = 4559;
+            else if (val == "sc" || val == "supercollider") port = 57120;
+            else if (val == "norns") port = 10111;
+            else port = val.getIntValue();
+
+            if (port >= 1000 && port <= 65535) {
+                {
+                    const juce::SpinLock::ScopedLockType lock(processor.pendingLock);
+                    processor.oscOutputPort = port;
+                }
+                processor.oscSender.reset();
+            }
+        }
+    }
+    else if (cmd.name == "ip") {
+        // ip:address — set target IP for UDP/OSC
+        if (cmd.value.isNotEmpty()) {
+            {
+                const juce::SpinLock::ScopedLockType lock(processor.pendingLock);
+                processor.udpTargetIP = cmd.value.trim();
+            }
+            processor.udpSocket.reset();
+            processor.oscSender.reset();
+        }
+    }
+    else if (cmd.name == "copy") {
+        // Trigger copy via keyboard simulation
+        editor.keyPressed(juce::KeyPress('C', juce::ModifierKeys::commandModifier, 0));
+    }
+    else if (cmd.name == "paste") {
+        editor.keyPressed(juce::KeyPress('V', juce::ModifierKeys::commandModifier, 0));
+    }
+    else if (cmd.name == "erase") {
+        editor.keyPressed(juce::KeyPress(juce::KeyPress::backspaceKey));
+    }
+    else if (cmd.name == "time") {
+        // Write current time to grid at cursor
+        if (!isLife) {
+            auto now = juce::Time::getCurrentTime();
+            auto timeStr = now.formatted("%H%M%S");
+            const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+            for (int i = 0; i < timeStr.length(); i++)
+                grid.write(editor.cursorX + i, editor.cursorY, (char)timeStr[i]);
+        }
+    }
+    else if (cmd.name == "color") {
+        // color:f_low;f_med;f_high (hex RGB values)
+        // For now, minimal implementation
+        if (cmd.parts.size() >= 3) {
+            auto parseHex = [](const juce::String& s) -> juce::Colour {
+                auto hex = s.trim();
+                if (hex.length() == 3) {
+                    // Expand shorthand: f00 → ff0000
+                    juce::String full;
+                    full << hex[0] << hex[0] << hex[1] << hex[1] << hex[2] << hex[2];
+                    return juce::Colour((uint32_t)full.getHexValue32() | 0xff000000u);
+                }
+                return juce::Colour((uint32_t)hex.getHexValue32() | 0xff000000u);
+            };
+            editor.bLow  = parseHex(cmd.parts[0]);
+            editor.bMed  = parseHex(cmd.parts[1]);
+            editor.bHigh = parseHex(cmd.parts[2]);
+        }
+    }
+
+    else if (cmd.name == "inject") {
+        // inject:name or inject:name;x;y — inject cached block at position
+        if (cmd.value.isNotEmpty()) {
+            juce::String name = cmd.parts[0];
+            int ix = (cmd.parts.size() >= 2) ? cmd.parts[1].getIntValue() : editor.cursorX;
+            int iy = (cmd.parts.size() >= 3) ? cmd.parts[2].getIntValue() : editor.cursorY;
+
+            // Auto-append extension if needed
+            if (!name.endsWithIgnoreCase(".orca") && !name.endsWithIgnoreCase(".life"))
+                name += isLife ? ".life" : ".orca";
+
+            auto it = editor.injectCache.find(name);
+            if (it != editor.injectCache.end()) {
+                editor.injectBlock(it->second, ix, iy);
+                editor.selectW = 1;
+                editor.selectH = 1;
+            }
+        }
+    }
+
+    // ── Life mode commands ──
+
+    else if (isLife && cmd.name == "scale") {
+        auto val = cmd.value.toLowerCase().trim();
+        for (int i = 0; i < orca::LifeGrid::NumScales; i++) {
+            if (val == juce::String(orca::LifeGrid::scaleName(
+                    static_cast<orca::LifeGrid::ScaleType>(i)))) {
+                processor.lifeScaleParam->setValueNotifyingHost(
+                    processor.lifeScaleParam->convertTo0to1(i));
+                break;
+            }
+        }
+    }
+    else if (isLife && cmd.name == "root") {
+        auto val = cmd.value.trim();
+        for (int i = 0; i < 12; i++) {
+            if (val.equalsIgnoreCase(orca::LifeGrid::rootNoteName(i))) {
+                processor.lifeRootParam->setValueNotifyingHost(
+                    processor.lifeRootParam->convertTo0to1(i));
+                break;
+            }
+        }
+    }
+    else if (isLife && cmd.name == "rate") {
+        int r = cmd.value.getIntValue();
+        if (r >= 1 && r <= 32)
+            processor.lifeRateParam->setValueNotifyingHost(
+                processor.lifeRateParam->convertTo0to1(r));
+    }
+    else if (isLife && (cmd.name == "pulse" || cmd.name == "hold")) {
+        processor.lifePulseParam->setValueNotifyingHost(cmd.name == "pulse" ? 1.0f : 0.0f);
+    }
+    else if (isLife && cmd.name == "decay") {
+        auto val = cmd.value.toLowerCase().trim();
+        bool on = (val == "on" || val == "1") ? true
+                : (val == "off" || val == "0") ? false
+                : !processor.lifeDecayParam->get();
+        processor.lifeDecayParam->setValueNotifyingHost(on ? 1.0f : 0.0f);
+    }
+    else if (isLife && cmd.name == "minvel") {
+        if (cmd.value.isNotEmpty())
+            processor.lifeMinVelParam->setValueNotifyingHost(
+                processor.lifeMinVelParam->convertTo0to1(juce::jlimit(1, 127, cmd.value.getIntValue())));
+    }
+    else if (isLife && cmd.name == "minprob") {
+        if (cmd.value.isNotEmpty())
+            processor.lifeMinProbParam->setValueNotifyingHost(
+                processor.lifeMinProbParam->convertTo0to1(juce::jlimit(1, 100, cmd.value.getIntValue())));
+    }
+    else if (isLife && cmd.name == "maxnotes") {
+        if (cmd.value.isNotEmpty())
+            processor.lifeMaxNotesParam->setValueNotifyingHost(
+                processor.lifeMaxNotesParam->convertTo0to1(juce::jmax(0, cmd.value.getIntValue())));
+    }
+    else if (isLife && cmd.name == "lockoct") {
+        auto val = cmd.value.toLowerCase().trim();
+        bool on = (val == "on" || val == "1") ? true
+                : (val == "off" || val == "0") ? false
+                : !processor.lifeLockOctParam->get();
+        processor.lifeLockOctParam->setValueNotifyingHost(on ? 1.0f : 0.0f);
+    }
+    else if (isLife && cmd.name == "chord") {
+        auto val = cmd.value.trim();
+        if (val == "off" || val == "0") {
+            processor.lifeChordParam->setValueNotifyingHost(0.0f); // index 0 = off
+        } else if (val.isNotEmpty()) {
+            int idx = processor.findChordPresetIndex(val);
+            if (idx == 0 && val != "off") {
+                // Not a preset — set directly on lifeGrid for custom values
+                engine.lifeGrid.setChordDegrees(val.toRawUTF8());
+            } else {
+                processor.lifeChordParam->setValueNotifyingHost(
+                    processor.lifeChordParam->convertTo0to1(idx));
+            }
+        } else {
+            // Toggle: off ↔ 135
+            int cur = processor.lifeChordParam->getIndex();
+            processor.lifeChordParam->setValueNotifyingHost(
+                processor.lifeChordParam->convertTo0to1(cur > 0 ? 0 : 1));
+        }
+    }
+    else if (isLife && cmd.name == "dedup") {
+        auto val = cmd.value.toLowerCase().trim();
+        bool on = (val == "on" || val == "1") ? true
+                : (val == "off" || val == "0") ? false
+                : !processor.lifeDedupParam->get();
+        processor.lifeDedupParam->setValueNotifyingHost(on ? 1.0f : 0.0f);
+    }
+    else if (isLife && cmd.name == "dedupcc") {
+        if (cmd.value.isNotEmpty())
+            processor.lifeDedupCCParam->setValueNotifyingHost(
+                processor.lifeDedupCCParam->convertTo0to1(juce::jlimit(-1, 127, cmd.value.getIntValue())));
+    }
+    else if (isLife && cmd.name == "seq") {
+        auto val = cmd.value.toLowerCase().trim();
+        int idx = -1;
+        if (val == "off" || val == "0") idx = 0;
+        else if (val == "forward" || val == "fwd" || val == "on" || val == "1") idx = 1;
+        else if (val == "reverse" || val == "rev") idx = 2;
+        else if (val == "mirror" || val == "mir") idx = 3;
+        else if (val == "random" || val == "rand" || val == "rnd") idx = 4;
+        else idx = (processor.lifeSeqParam->getIndex() == 0) ? 1 : 0; // toggle
+        processor.lifeSeqParam->setValueNotifyingHost(
+            processor.lifeSeqParam->convertTo0to1(idx));
+    }
+    else if (isLife && cmd.name == "rule") {
+        auto val = cmd.value.toLowerCase().trim();
+        if (val.containsChar('/')) {
+            // Custom S/B notation — set directly on lifeGrid
+            engine.lifeGrid.setRuleFromString(val.toRawUTF8());
+        } else {
+            // Named preset — find index
+            for (int i = 0; i < OrcaProcessor::numRulePresets; i++) {
+                if (val == OrcaProcessor::rulePresets[i]) {
+                    processor.lifeRuleParam->setValueNotifyingHost(
+                        processor.lifeRuleParam->convertTo0to1(i));
+                    break;
+                }
+            }
+        }
+    }
+    else if (isLife && cmd.name == "channel") {
+        if (cmd.value.isNotEmpty())
+            engine.paintChannel = static_cast<uint8_t>(
+                juce::jlimit(0, 15, cmd.value.getIntValue()));
+    }
+    else if (isLife && cmd.name == "octave") {
+        if (cmd.value.isNotEmpty())
+            engine.paintOctave = static_cast<uint8_t>(
+                juce::jlimit(0, processor.lifeMaxOctParam->get(), cmd.value.getIntValue()));
+    }
+    else if (isLife && cmd.name == "maxoct") {
+        if (cmd.value.isNotEmpty()) {
+            int v = juce::jlimit(0, 8, cmd.value.getIntValue());
+            processor.lifeMaxOctParam->setValueNotifyingHost(
+                processor.lifeMaxOctParam->convertTo0to1(v));
+            if (processor.lifeMinOctParam->get() > v)
+                processor.lifeMinOctParam->setValueNotifyingHost(
+                    processor.lifeMinOctParam->convertTo0to1(v));
+        }
+    }
+    else if (isLife && cmd.name == "minoct") {
+        if (cmd.value.isNotEmpty()) {
+            int v = juce::jlimit(0, 8, cmd.value.getIntValue());
+            processor.lifeMinOctParam->setValueNotifyingHost(
+                processor.lifeMinOctParam->convertTo0to1(v));
+            if (processor.lifeMaxOctParam->get() < v)
+                processor.lifeMaxOctParam->setValueNotifyingHost(
+                    processor.lifeMaxOctParam->convertTo0to1(v));
+        }
+    }
+    else if (isLife && cmd.name == "reset") {
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+        orca::MidiEvent events[orca::kMaxEvents];
+        int eventCount = engine.lifeGrid.resetToInitial(events, orca::kMaxEvents);
+        for (int i = 0; i < eventCount; i++)
+            processor.pushLifeEvent(events[i]);
+    }
+    else {
+        handled = false;
+    }
+
+    stop();
+    return handled;
+}
+
+void Commander::preview(OrcaProcessor& processor, GridComponent& editor) {
+    auto cmd = parse();
+    findHighlights.clear();
+    hasFindPreview = false;
+
+    auto& engine = processor.engine;
+    bool isLife = engine.lifeMode;
+
+    if (cmd.name == "find" && cmd.value.isNotEmpty()) {
+        hasFindPreview = true;
+        auto target = cmd.value;
+        int len = target.length();
+        int gw = isLife ? engine.lifeGrid.w : engine.grid.w;
+        int gh = isLife ? engine.lifeGrid.h : engine.grid.h;
+        for (int y = 0; y < gh; y++) {
+            for (int x = 0; x <= gw - len; x++) {
+                bool match = true;
+                for (int i = 0; i < len && match; i++) {
+                    char gc;
+                    if (isLife) {
+                        int idx = engine.lifeGrid.indexAt(x + i, y);
+                        gc = (idx >= 0 && engine.lifeGrid.cells[idx].alive)
+                             ? engine.lifeGrid.cells[idx].note : '.';
+                    } else {
+                        gc = engine.grid.glyphAt(x + i, y);
+                    }
+                    if (gc != (char)target[i]) match = false;
+                }
+                if (match) {
+                    for (int i = 0; i < len; i++)
+                        findHighlights.add(x + i + gw * y);
+                }
+            }
+        }
+    }
+
+    // Inject preview: show selection scaled to block dimensions
+    if (cmd.name == "inject" && cmd.value.isNotEmpty()) {
+        juce::String name = cmd.parts[0];
+        if (!name.endsWithIgnoreCase(".orca") && !name.endsWithIgnoreCase(".life"))
+            name += isLife ? ".life" : ".orca";
+
+        auto it = editor.injectCache.find(name);
+        if (it != editor.injectCache.end()) {
+            auto lines = juce::StringArray::fromLines(it->second);
+            while (lines.size() > 0 && lines[lines.size() - 1].trimEnd().isEmpty())
+                lines.remove(lines.size() - 1);
+
+            if (lines.size() > 0) {
+                int bh = lines.size();
+                int bw = 0;
+
+                // For .life files, parse header for dimensions
+                if (lines[0].startsWith("LIFE ")) {
+                    auto tokens = juce::StringArray::fromTokens(lines[0], " ", "");
+                    bw = (tokens.size() >= 2) ? tokens[1].getIntValue() : 0;
+                    bh = (tokens.size() >= 3) ? tokens[2].getIntValue() : lines.size() - 1;
+                } else {
+                    for (auto& line : lines)
+                        bw = juce::jmax(bw, line.length());
+                }
+
+                if (cmd.parts.size() >= 2) editor.cursorX = cmd.parts[1].getIntValue();
+                if (cmd.parts.size() >= 3) editor.cursorY = cmd.parts[2].getIntValue();
+                editor.selectW = juce::jmax(1, bw);
+                editor.selectH = juce::jmax(1, bh);
+            }
+        }
+    }
 }
 
 // ── Operator name lookup ──

--- a/plugin/Source/PluginEditor.cpp
+++ b/plugin/Source/PluginEditor.cpp
@@ -189,6 +189,13 @@ void GridComponent::paint(juce::Graphics& g) {
                   << (engine.lifeGrid.lockOctave ? "  lockoct" : "")
                   << (engine.lifeGrid.chordDegreeCount > 0 ? juce::String("  chord:") + engine.lifeGrid.chordDegreesString() : juce::String())
                   << (engine.lifeGrid.dedup ? juce::String("  dedup") + (engine.lifeGrid.dedupCC >= 0 ? juce::String(" cc:") + juce::String(engine.lifeGrid.dedupCC) : juce::String()) : juce::String())
+                  << (engine.lifeGrid.conductorMode ? "  conductor" : "")
+                  << (engine.lifeGrid.microtuning ? juce::String("  microtune:") + juce::String(engine.lifeGrid.microtuneAmount) : juce::String())
+                  << (engine.lifeGrid.loopState == orca::LifeGrid::LoopRecording ?
+                      juce::String("  loop:rec ") + juce::String(engine.lifeGrid.loopHead) + "/" + juce::String(engine.lifeGrid.loopLength) :
+                      engine.lifeGrid.loopState == orca::LifeGrid::LoopPlaying ?
+                      juce::String("  loop:") + juce::String(engine.lifeGrid.loopHead + 1) + "/" + juce::String(engine.lifeGrid.loopRecorded) :
+                      juce::String())
                   << (strcmp(engine.lifeGrid.ruleString, "23/3") != 0 ? juce::String("  rule:") + juce::String(engine.lifeGrid.ruleString) : juce::String())
                   << ((engine.lifeGrid.minOctave != 0 || engine.lifeGrid.maxOctave != 7) ?
                       juce::String("  oct:") + juce::String(engine.lifeGrid.minOctave) + "-" + juce::String(engine.lifeGrid.maxOctave) :
@@ -752,6 +759,39 @@ bool GridComponent::keyPressed(const juce::KeyPress& key) {
         }
     }
 
+    // Life mode: Cmd+T = toggle conductor mode
+    if (cmd && !shift && code == 'T') {
+        auto& engine = processor.engine;
+        if (engine.lifeMode) {
+            processor.lifeConductorParam->setValueNotifyingHost(
+                processor.lifeConductorParam->get() ? 0.0f : 1.0f);
+            return true;
+        }
+    }
+
+    // Life mode: Cmd+U = toggle microtuning
+    if (cmd && !shift && code == 'U') {
+        auto& engine = processor.engine;
+        if (engine.lifeMode) {
+            processor.lifeMicrotuneParam->setValueNotifyingHost(
+                processor.lifeMicrotuneParam->get() ? 0.0f : 1.0f);
+            return true;
+        }
+    }
+
+    // Life mode: Cmd+E = toggle loop play/off
+    if (cmd && !shift && code == 'E') {
+        auto& engine = processor.engine;
+        if (engine.lifeMode) {
+            const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+            if (engine.lifeGrid.loopState == orca::LifeGrid::LoopPlaying)
+                engine.lifeGrid.stopLoop();
+            else if (engine.lifeGrid.loopRecorded > 0)
+                engine.lifeGrid.startLoopPlayback();
+            return true;
+        }
+    }
+
     // Life mode: Cmd+Shift+K = toggle lock (protect) selected cells
     if (cmd && shift && code == 'K') {
         auto& engine = processor.engine;
@@ -797,6 +837,13 @@ bool GridComponent::keyPressed(const juce::KeyPress& key) {
         else
             stampCategory = (stampCategory - 1 + numStampCategories) % numStampCategories;
         stampIndex = stampCategories[stampCategory].start;
+        return true;
+    }
+
+    // Conductor mode: Enter = trigger next evolution
+    if (!stampMode && !cmd && !shift && code == juce::KeyPress::returnKey
+        && processor.engine.lifeMode && processor.engine.lifeGrid.conductorMode) {
+        processor.engine.lifeGrid.conductorTrigger.store(true, std::memory_order_relaxed);
         return true;
     }
 
@@ -2046,6 +2093,46 @@ bool Commander::trigger(OrcaProcessor& processor, GridComponent& editor) {
             if (processor.lifeMaxOctParam->get() < v)
                 processor.lifeMaxOctParam->setValueNotifyingHost(
                     processor.lifeMaxOctParam->convertTo0to1(v));
+        }
+    }
+    else if (isLife && cmd.name == "conductor") {
+        auto val = cmd.value.toLowerCase().trim();
+        bool on;
+        if (val == "on") on = true;
+        else if (val == "off") on = false;
+        else on = !processor.lifeConductorParam->get(); // toggle
+        processor.lifeConductorParam->setValueNotifyingHost(on ? 1.0f : 0.0f);
+    }
+    else if (isLife && cmd.name == "microtune") {
+        auto val = cmd.value.toLowerCase().trim();
+        if (val == "on") {
+            processor.lifeMicrotuneParam->setValueNotifyingHost(1.0f);
+        } else if (val == "off") {
+            processor.lifeMicrotuneParam->setValueNotifyingHost(0.0f);
+        } else if (val.isNotEmpty() && val.containsOnly("0123456789")) {
+            int amt = juce::jlimit(0, 100, val.getIntValue());
+            processor.lifeMicrotuneAmtParam->setValueNotifyingHost(
+                processor.lifeMicrotuneAmtParam->convertTo0to1(amt));
+            if (!processor.lifeMicrotuneParam->get())
+                processor.lifeMicrotuneParam->setValueNotifyingHost(1.0f);
+        } else {
+            bool on = !processor.lifeMicrotuneParam->get();
+            processor.lifeMicrotuneParam->setValueNotifyingHost(on ? 1.0f : 0.0f);
+        }
+    }
+    else if (isLife && cmd.name == "loop") {
+        auto val = cmd.value.toLowerCase().trim();
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+        if (val == "off" || val == "stop" || val == "0") {
+            engine.lifeGrid.stopLoop();
+        } else if (val.isNotEmpty() && val.containsOnly("0123456789")) {
+            int len = juce::jlimit(1, 64, val.getIntValue());
+            engine.lifeGrid.armLoop(len);
+        } else {
+            if (engine.lifeGrid.loopState == orca::LifeGrid::LoopPlaying)
+                engine.lifeGrid.stopLoop();
+            else if (engine.lifeGrid.loopRecorded > 0)
+                engine.lifeGrid.startLoopPlayback();
         }
     }
     else if (isLife && cmd.name == "reset") {

--- a/plugin/Source/PluginEditor.h
+++ b/plugin/Source/PluginEditor.h
@@ -4,6 +4,9 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "PluginProcessor.h"
 #include "engine/Operator.h"
+#include "engine/LifeGrid.h"
+#include "Commander.h"
+#include <map>
 
 class GridComponent : public juce::Component,
                       public juce::Timer,
@@ -18,6 +21,7 @@ public:
 
     // Keyboard input
     bool keyPressed(const juce::KeyPress& key) override;
+    void visibilityChanged() override;
     void mouseDown(const juce::MouseEvent& event) override;
     void mouseDrag(const juce::MouseEvent& event) override;
 
@@ -26,9 +30,23 @@ public:
     void filesDropped(const juce::StringArray& files, int x, int y) override;
     void loadOrcaFile(const juce::File& file);
     void saveOrcaFile(const juce::File& file);
+    void loadLifeFile(const juce::File& file);
+    void saveLifeFile(const juce::File& file);
     void saveAs();
 
     juce::File currentFile; // currently loaded/saved file path
+
+    // Commander (command prompt)
+    Commander commander;
+
+    // Inject cache (loaded via Cmd+L, referenced by inject: command)
+    std::map<juce::String, juce::String> injectCache;
+    void injectBlock(const juce::String& content, int atX, int atY);
+
+    // Stamp mode (pattern preview + placement)
+    bool stampMode = false;
+    int stampIndex = 0;    // index into builtInPatterns
+    int stampCategory = 0; // current category index
 
     // Cursor
     int cursorX = 0, cursorY = 0;
@@ -37,9 +55,10 @@ public:
 
     // Clipboard
     char clipboard[orca::kMaxGridSize];
+    orca::LifeCell lifeClipboard[orca::kMaxGridSize];
     int clipW = 0, clipH = 0;
 
-    // Undo/Redo
+    // Undo/Redo (normal Orca mode)
     static constexpr int kMaxHistory = 128;
     struct Snapshot {
         char cells[orca::kMaxGridSize];
@@ -51,6 +70,21 @@ public:
     void pushHistory();
     void undo();
     void redo();
+
+    // Undo/Redo (Life mode)
+    static constexpr int kMaxLifeHistory = 64;
+    struct LifeSnapshot {
+        orca::LifeCell cells[orca::kMaxGridSize];
+        int w, h;
+    };
+    LifeSnapshot* lifeHistory = nullptr; // heap-allocated on demand
+    int lifeHistoryCount = 0;
+    int lifeHistoryPos = -1;
+    void pushLifeHistory();
+    void undoLife();
+    void redoLife();
+
+    friend class Commander;
 
 private:
     OrcaProcessor& processor;
@@ -74,8 +108,18 @@ private:
     juce::Font monoFont;
     std::unique_ptr<juce::FileChooser> fileChooser;
 
+    // Life mode channel colors (16 channels)
+    static constexpr uint32_t channelColorValues[16] = {
+        0xffff5555, 0xffff8844, 0xffffcc33, 0xff88ee44,
+        0xff44dd66, 0xff44ddaa, 0xff44ccdd, 0xff4488ee,
+        0xff5555ff, 0xff8844ff, 0xffbb44ee, 0xffdd44aa,
+        0xffee4477, 0xffaa6644, 0xff888888, 0xffeeeeee,
+    };
+
     void drawCell(juce::Graphics& g, int x, int y, char glyph,
                   uint8_t portType, bool isLocked, bool isSelected);
+    void drawLifeCell(juce::Graphics& g, int x, int y,
+                      const orca::LifeCell& cell, bool isSelected);
 
     static const char* operatorName(char glyph);
     static const char* portName(char ownerGlyph, int portIdx);

--- a/plugin/Source/PluginProcessor.cpp
+++ b/plugin/Source/PluginProcessor.cpp
@@ -2,34 +2,163 @@
 #include "PluginEditor.h"
 #include <mach/mach_time.h>
 
+juce::AudioProcessorValueTreeState::ParameterLayout OrcaProcessor::createParameterLayout() {
+    juce::AudioProcessorValueTreeState::ParameterLayout layout;
+
+    // ── Shuffle ──
+    auto shuffleGroup = std::make_unique<juce::AudioProcessorParameterGroup>("shuffle_group", "Shuffle", "|");
+    shuffleGroup->addChild(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID("shuffle", 1), "Shuffle",
+        juce::NormalisableRange<float>(0.0f, 200.0f, 1.0f), 100.0f,
+        juce::AudioParameterFloatAttributes().withLabel("%")));
+    layout.add(std::move(shuffleGroup));
+
+    // ── Life: Timing ──
+    auto timingGroup = std::make_unique<juce::AudioProcessorParameterGroup>("life_timing", "Life: Timing", "|");
+    timingGroup->addChild(std::make_unique<juce::AudioParameterInt>(
+        juce::ParameterID("life_rate", 1), "Evolve Rate", 1, 32, 4));
+    timingGroup->addChild(std::make_unique<juce::AudioParameterChoice>(
+        juce::ParameterID("life_seq", 1), "Seq Mode",
+        juce::StringArray{"Off", "Forward", "Reverse", "Mirror", "Random"}, 0));
+    timingGroup->addChild(std::make_unique<juce::AudioParameterBool>(
+        juce::ParameterID("life_pulse", 1), "Pulse Mode", true));
+    layout.add(std::move(timingGroup));
+
+    // ── Life: Pitch ──
+    auto pitchGroup = std::make_unique<juce::AudioProcessorParameterGroup>("life_pitch", "Life: Pitch", "|");
+    pitchGroup->addChild(std::make_unique<juce::AudioParameterChoice>(
+        juce::ParameterID("life_scale", 1), "Scale",
+        juce::StringArray{"Chromatic", "Major", "Minor", "Pentatonic", "Dorian",
+                          "Phrygian", "Lydian", "Mixolydian", "Locrian",
+                          "Harmonic Minor", "Melodic Minor", "Minor Pentatonic",
+                          "Blues", "Whole Tone", "Diminished"}, 0));
+    pitchGroup->addChild(std::make_unique<juce::AudioParameterChoice>(
+        juce::ParameterID("life_root", 1), "Root Note",
+        juce::StringArray{"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"}, 0));
+    pitchGroup->addChild(std::make_unique<juce::AudioParameterInt>(
+        juce::ParameterID("life_minoct", 1), "Min Octave", 0, 8, 0));
+    pitchGroup->addChild(std::make_unique<juce::AudioParameterInt>(
+        juce::ParameterID("life_maxoct", 1), "Max Octave", 0, 8, 7));
+    pitchGroup->addChild(std::make_unique<juce::AudioParameterBool>(
+        juce::ParameterID("life_lockoct", 1), "Lock Octave", false));
+    pitchGroup->addChild(std::make_unique<juce::AudioParameterChoice>(
+        juce::ParameterID("life_chord", 1), "Chord Filter",
+        juce::StringArray{"Off", "135", "1357", "125", "145", "1356", "12356", "1234567"}, 0));
+    layout.add(std::move(pitchGroup));
+
+    // ── Life: Dynamics ──
+    auto dynGroup = std::make_unique<juce::AudioProcessorParameterGroup>("life_dynamics", "Life: Dynamics", "|");
+    dynGroup->addChild(std::make_unique<juce::AudioParameterBool>(
+        juce::ParameterID("life_decay", 1), "Decay", false));
+    dynGroup->addChild(std::make_unique<juce::AudioParameterInt>(
+        juce::ParameterID("life_minvel", 1), "Min Velocity", 1, 127, 40));
+    dynGroup->addChild(std::make_unique<juce::AudioParameterInt>(
+        juce::ParameterID("life_minprob", 1), "Min Probability", 1, 100, 10));
+    dynGroup->addChild(std::make_unique<juce::AudioParameterInt>(
+        juce::ParameterID("life_maxnotes", 1), "Max Notes", 0, 32, 0));
+    layout.add(std::move(dynGroup));
+
+    // ── Life: Processing ──
+    auto procGroup = std::make_unique<juce::AudioProcessorParameterGroup>("life_processing", "Life: Processing", "|");
+    procGroup->addChild(std::make_unique<juce::AudioParameterBool>(
+        juce::ParameterID("life_dedup", 1), "Dedup", false));
+    procGroup->addChild(std::make_unique<juce::AudioParameterInt>(
+        juce::ParameterID("life_dedupcc", 1), "Dedup CC", -1, 127, -1));
+    procGroup->addChild(std::make_unique<juce::AudioParameterChoice>(
+        juce::ParameterID("life_rule", 1), "CA Rule",
+        juce::StringArray{"Life", "HighLife", "Seeds", "Day & Night", "Diamoeba",
+                          "Replicator", "2x2", "Morley", "34 Life"}, 0));
+    layout.add(std::move(procGroup));
+
+    return layout;
+}
+
 OrcaProcessor::OrcaProcessor()
     : AudioProcessor(BusesProperties()
-                     .withOutput("Output", juce::AudioChannelSet::stereo(), true))
+                     .withOutput("Output", juce::AudioChannelSet::stereo(), true)),
+      apvts(*this, nullptr, "Parameters", createParameterLayout())
 {
     engine.reset(25, 25);
 
-    // DAW-exposed shuffle parameter (0-200%)
-    // 0% = max inverse swing (1;99), 100% = straight, 200% = max swing (99;1)
-    auto* param = new juce::AudioParameterFloat(
-        juce::ParameterID("shuffle", 1),
-        "Shuffle",
-        juce::NormalisableRange<float>(0.0f, 200.0f, 1.0f),
-        100.0f,
-        juce::AudioParameterFloatAttributes().withLabel("%"));
-    shuffleParam = param;
-    addParameter(param);
+    // Cache raw parameter pointers for fast audio-thread reads
+    shuffleParam     = dynamic_cast<juce::AudioParameterFloat*> (apvts.getParameter("shuffle"));
+    lifeRateParam    = dynamic_cast<juce::AudioParameterInt*>   (apvts.getParameter("life_rate"));
+    lifeDecayParam   = dynamic_cast<juce::AudioParameterBool*>  (apvts.getParameter("life_decay"));
+    lifeMinVelParam  = dynamic_cast<juce::AudioParameterInt*>   (apvts.getParameter("life_minvel"));
+    lifeMinProbParam = dynamic_cast<juce::AudioParameterInt*>   (apvts.getParameter("life_minprob"));
+    lifeMaxNotesParam= dynamic_cast<juce::AudioParameterInt*>   (apvts.getParameter("life_maxnotes"));
+    lifeSeqParam     = dynamic_cast<juce::AudioParameterChoice*>(apvts.getParameter("life_seq"));
+    lifeLockOctParam = dynamic_cast<juce::AudioParameterBool*>  (apvts.getParameter("life_lockoct"));
+    lifeChordParam   = dynamic_cast<juce::AudioParameterChoice*>(apvts.getParameter("life_chord"));
+    lifeDedupParam   = dynamic_cast<juce::AudioParameterBool*>  (apvts.getParameter("life_dedup"));
+    lifeDedupCCParam = dynamic_cast<juce::AudioParameterInt*>   (apvts.getParameter("life_dedupcc"));
+    lifeMinOctParam  = dynamic_cast<juce::AudioParameterInt*>   (apvts.getParameter("life_minoct"));
+    lifeMaxOctParam  = dynamic_cast<juce::AudioParameterInt*>   (apvts.getParameter("life_maxoct"));
+    lifeScaleParam   = dynamic_cast<juce::AudioParameterChoice*>(apvts.getParameter("life_scale"));
+    lifeRootParam    = dynamic_cast<juce::AudioParameterChoice*>(apvts.getParameter("life_root"));
+    lifePulseParam   = dynamic_cast<juce::AudioParameterBool*>  (apvts.getParameter("life_pulse"));
+    lifeRuleParam    = dynamic_cast<juce::AudioParameterChoice*>(apvts.getParameter("life_rule"));
 
     // Create virtual MIDI port via CoreMIDI C API (bypasses JUCE's broken singleton)
+    midiClient = 0;
+    midiEndpoint = 0;
     OSStatus status = MIDIClientCreate(CFSTR("OrcaPlugin"), nullptr, nullptr, &midiClient);
     if (status == noErr)
         MIDISourceCreate(midiClient, CFSTR("Orca"), &midiEndpoint);
 }
 
+int OrcaProcessor::findChordPresetIndex(const juce::String& degrees) const {
+    for (int i = 0; i < numChordPresets; i++)
+        if (degrees == chordPresets[i]) return i;
+    return 0; // "off"
+}
+
+void OrcaProcessor::syncParamsToLifeGrid() {
+    auto& lg = engine.lifeGrid;
+    lg.evolveRate   = lifeRateParam->get();
+    lg.decay        = lifeDecayParam->get();
+    lg.minVelocity  = static_cast<uint8_t>(lifeMinVelParam->get());
+    lg.minProb      = lifeMinProbParam->get();
+    lg.maxNotes     = lifeMaxNotesParam->get();
+    lg.seqMode      = static_cast<orca::LifeGrid::SeqMode>(lifeSeqParam->getIndex());
+    lg.lockOctave   = lifeLockOctParam->get();
+    lg.dedup        = lifeDedupParam->get();
+    lg.dedupCC      = lifeDedupCCParam->get();
+    lg.minOctave    = lifeMinOctParam->get();
+    lg.maxOctave    = lifeMaxOctParam->get();
+    if (lg.minOctave > lg.maxOctave) lg.minOctave = lg.maxOctave;
+    lg.pulseMode    = lifePulseParam->get();
+    lg.currentScale = static_cast<orca::LifeGrid::ScaleType>(lifeScaleParam->getIndex());
+    lg.rootNote     = lifeRootParam->getIndex();
+
+    // Chord filter: map choice index to degree string
+    int chordIdx = lifeChordParam->getIndex();
+    if (chordIdx == 0)
+        lg.chordDegreeCount = 0;
+    else
+        lg.setChordDegrees(chordPresets[chordIdx]);
+
+    // CA rule: map choice index to preset
+    int ruleIdx = lifeRuleParam->getIndex();
+    if (ruleIdx >= 0 && ruleIdx < numRulePresets)
+        lg.setRulePreset(rulePresets[ruleIdx]);
+}
+
 OrcaProcessor::~OrcaProcessor() {
+    // Tear down network sockets before MIDI
+    oscSender.reset();
+    udpSocket.reset();
+
     if (midiEndpoint) MIDIEndpointDispose(midiEndpoint);
     if (midiClient)   MIDIClientDispose(midiClient);
     midiEndpoint = 0;
     midiClient = 0;
+}
+
+void OrcaProcessor::setupUdpSocket() {
+    udpSocket = std::make_unique<juce::DatagramSocket>();
+    if (!udpSocket->bindToPort(0))
+        DBG("UDP: Failed to bind socket");
 }
 
 void OrcaProcessor::sendMidiToVirtualPort(const uint8_t* data, int numBytes) {
@@ -102,6 +231,10 @@ void OrcaProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuf
         }
     }
 
+    // Sync Life mode parameters from APVTS → engine
+    if (engine.lifeMode)
+        syncParamsToLifeGrid();
+
     // Get DAW transport state
     double bpm = 120.0;
     bool isPlaying = false;
@@ -120,6 +253,14 @@ void OrcaProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuf
         }
     }
 
+    // Standalone mode: use internal play state with accumulator timing
+    if (wrapperType == wrapperType_Standalone && standalonePlay.load(std::memory_order_relaxed)) {
+        isPlaying = true;
+        hasPpq = false; // force accumulator path — standalone has no meaningful PPQ
+    }
+
+    transportRunning.store(isPlaying, std::memory_order_relaxed);
+
     // Reset frames when DAW transport stops
     if (!isPlaying) {
         if (wasPlaying) {
@@ -128,15 +269,63 @@ void OrcaProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuf
             lastPpqFrame = -1;
             grooveIndex = 0;
             wasPlaying = false;
+            // Silence Life mode notes on stop and reset sequencer phase
+            if (engine.lifeMode) {
+                orca::MidiEvent events[orca::kMaxEvents];
+                int eventCount = 0;
+                // Silence ratchets first
+                eventCount += engine.lifeGrid.silenceRatchets(events + eventCount, orca::kMaxEvents - eventCount);
+                engine.lifeGrid.ratchetCount = 0;
+                // Silence all active notes
+                eventCount += engine.lifeGrid.silence(events + eventCount, orca::kMaxEvents - eventCount);
+                for (int i = 0; i < eventCount; i++) {
+                    midiMessages.addEvent(events[i].bytes, events[i].numBytes, 0);
+                    sendMidiToVirtualPort(events[i].bytes, events[i].numBytes);
+                }
+                // Reset sequencer state so next step() triggers evolution immediately
+                engine.lifeGrid.frameCounter = engine.lifeGrid.evolveRate - 1;
+                engine.lifeGrid.phaseNoteCount = 0;
+                engine.lifeGrid.firstEvolution = true;
+            }
         }
         return;
     }
+    // Retrigger alive Life notes on transport start (skip in seq mode — let phase handle it)
+    if (!wasPlaying && engine.lifeMode && engine.lifeGrid.seqMode == orca::LifeGrid::SeqOff) {
+        orca::MidiEvent events[orca::kMaxEvents];
+        int count = engine.lifeGrid.triggerAlive(events, orca::kMaxEvents);
+        for (int i = 0; i < count; i++) {
+            midiMessages.addEvent(events[i].bytes, events[i].numBytes, 0);
+            sendMidiToVirtualPort(events[i].bytes, events[i].numBytes);
+        }
+    }
     wasPlaying = true;
+
+    // Dispatch any pending Life mode events (e.g. note-offs from mode exit)
+    {
+        orca::MidiEvent localEvents[kMaxPendingLifeEvents];
+        int localCount = 0;
+        {
+            const juce::SpinLock::ScopedLockType lock(pendingLock);
+            localCount = pendingLifeEventCount;
+            for (int i = 0; i < localCount; i++)
+                localEvents[i] = pendingLifeEvents[i];
+            pendingLifeEventCount = 0;
+        }
+        for (int i = 0; i < localCount; i++) {
+            midiMessages.addEvent(localEvents[i].bytes, localEvents[i].numBytes, 0);
+            sendMidiToVirtualPort(localEvents[i].bytes, localEvents[i].numBytes);
+        }
+    }
 
     // Helper to dispatch MIDI events from a step
     auto dispatchEvents = [&](int sampleOffset) {
         orca::MidiEvent events[orca::kMaxEvents];
-        int eventCount = engine.step(events, orca::kMaxEvents);
+        int eventCount;
+        {
+            const juce::SpinLock::ScopedLockType lock(engineLock);
+            eventCount = engine.step(events, orca::kMaxEvents);
+        }
         for (int i = 0; i < eventCount; i++) {
             auto& e = events[i];
             midiMessages.addEvent(e.bytes, e.numBytes,
@@ -147,17 +336,70 @@ void OrcaProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuf
                 lastNoteOnPitch.store(e.bytes[1], std::memory_order_relaxed);
             }
         }
+        // Drain $ operator commands, UDP, and OSC messages to UI thread
+        if (engine.io.udpCount > 0) {
+            udpSendCount.fetch_add(engine.io.udpCount, std::memory_order_relaxed);
+            DBG("dispatchEvents: udp=" + juce::String(engine.io.udpCount) + " osc=" + juce::String(engine.io.oscCount));
+        }
+        if (engine.io.commandCount > 0 || engine.io.udpCount > 0 || engine.io.oscCount > 0) {
+            const juce::SpinLock::ScopedLockType lock(pendingLock);
+
+            // Commands
+            for (int i = 0; i < engine.io.commandCount && pendingCommandCount < kMaxPendingCommands; i++) {
+                int len = 0;
+                while (len < kMaxPendingCommandLen - 1 && engine.io.commands[i][len] != '\0') {
+                    pendingCommands[pendingCommandCount][len] = engine.io.commands[i][len];
+                    len++;
+                }
+                pendingCommands[pendingCommandCount][len] = '\0';
+                pendingCommandCount++;
+            }
+            engine.io.clearCommands();
+
+            // UDP
+            for (int i = 0; i < engine.io.udpCount && pendingUdpCount < kMaxPendingUdp; i++) {
+                int len = 0;
+                while (len < kMaxPendingUdpLen - 1 && engine.io.udpMessages[i][len] != '\0') {
+                    pendingUdp[pendingUdpCount][len] = engine.io.udpMessages[i][len];
+                    len++;
+                }
+                pendingUdp[pendingUdpCount][len] = '\0';
+                pendingUdpCount++;
+            }
+            engine.io.clearUdp();
+
+            // OSC
+            for (int i = 0; i < engine.io.oscCount && pendingOscCount < kMaxPendingOsc; i++) {
+                pendingOsc[pendingOscCount].path = engine.io.oscMessages[i].path;
+                pendingOsc[pendingOscCount].dataLen = engine.io.oscMessages[i].dataLen;
+                for (int j = 0; j < engine.io.oscMessages[i].dataLen; j++)
+                    pendingOsc[pendingOscCount].data[j] = engine.io.oscMessages[i].data[j];
+                pendingOsc[pendingOscCount].data[engine.io.oscMessages[i].dataLen] = '\0';
+                pendingOscCount++;
+            }
+            engine.io.clearOsc();
+        }
     };
 
     if (hasPpq) {
         // PPQ-based sync with groove support
+        // Snapshot groove config under lock (UI thread may update via commander)
+        double localGrooves[kMaxGrooveSlots];
+        int localGrooveLength;
+        {
+            const juce::SpinLock::ScopedLockType lock(pendingLock);
+            localGrooveLength = grooveLength;
+            for (int i = 0; i < localGrooveLength; i++)
+                localGrooves[i] = grooves[i];
+        }
+
         // Precompute cumulative PPQ thresholds for one groove cycle
         constexpr double ppqPerSixteenth = 0.25;
         double grooveCumulPpq[kMaxGrooveSlots + 1];
         grooveCumulPpq[0] = 0.0;
-        for (int i = 0; i < grooveLength; i++)
-            grooveCumulPpq[i + 1] = grooveCumulPpq[i] + grooves[i] * ppqPerSixteenth;
-        double grooveCyclePpq = grooveCumulPpq[grooveLength]; // total PPQ for one cycle
+        for (int i = 0; i < localGrooveLength; i++)
+            grooveCumulPpq[i + 1] = grooveCumulPpq[i] + localGrooves[i] * ppqPerSixteenth;
+        double grooveCyclePpq = grooveCumulPpq[localGrooveLength]; // total PPQ for one cycle
 
         int numSamples = buffer.getNumSamples();
         double ppqPerSample = bpm / (60.0 * currentSampleRate);
@@ -172,11 +414,11 @@ void OrcaProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuf
 
             // Find which frame within the cycle
             int frameInCycle = 0;
-            for (int i = 0; i < grooveLength; i++) {
+            for (int i = 0; i < localGrooveLength; i++) {
                 if (ppqInCycle >= grooveCumulPpq[i])
                     frameInCycle = i;
             }
-            int grooveFrame = cycleNum * grooveLength + frameInCycle;
+            int grooveFrame = cycleNum * localGrooveLength + frameInCycle;
 
             if (grooveFrame != lastPpqFrame) {
                 lastPpqFrame = grooveFrame;
@@ -187,19 +429,30 @@ void OrcaProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuf
         }
     } else {
         // Fallback: accumulator-based timing with groove support
+        // Snapshot groove config under lock
+        double localGrooves[kMaxGrooveSlots];
+        int localGrooveLength;
+        {
+            const juce::SpinLock::ScopedLockType lock(pendingLock);
+            localGrooveLength = grooveLength;
+            for (int i = 0; i < localGrooveLength; i++)
+                localGrooves[i] = grooves[i];
+        }
+
         double baseSamplesPerStep = currentSampleRate * 60.0 / (bpm * 4.0);
         int numSamples = buffer.getNumSamples();
 
         int samplePos = 0;
         while (samplePos < numSamples) {
-            double currentStep = baseSamplesPerStep * grooves[grooveIndex];
+            int gi = grooveIndex % localGrooveLength;
+            double currentStep = baseSamplesPerStep * localGrooves[gi];
             double samplesToNext = currentStep - frameAccumulator;
             int samplesToNextInt = static_cast<int>(std::ceil(samplesToNext));
 
             if (samplePos + samplesToNextInt <= numSamples) {
                 samplePos += samplesToNextInt;
                 frameAccumulator = 0.0;
-                grooveIndex = (grooveIndex + 1) % grooveLength;
+                grooveIndex = (grooveIndex + 1) % localGrooveLength;
                 dispatchEvents(samplePos);
             } else {
                 frameAccumulator += static_cast<double>(numSamples - samplePos);
@@ -238,6 +491,43 @@ void OrcaProcessor::getStateInformation(juce::MemoryBlock& destData) {
     }
     xml->setAttribute("groove", grooveStr);
 
+    // Save Life mode state
+    xml->setAttribute("lifeMode", engine.lifeMode ? 1 : 0);
+    xml->setAttribute("paintChannel", (int)engine.paintChannel);
+    xml->setAttribute("paintOctave", (int)engine.paintOctave);
+    if (engine.lifeMode) {
+        // Save alive cells as compact format: x,y,note,channel,octave;...
+        juce::String lifeStr;
+        for (int y = 0; y < engine.lifeGrid.h; y++) {
+            for (int x = 0; x < engine.lifeGrid.w; x++) {
+                int idx = x + engine.lifeGrid.w * y;
+                auto& cell = engine.lifeGrid.cells[idx];
+                if (cell.alive) {
+                    if (lifeStr.isNotEmpty()) lifeStr += ";";
+                    lifeStr += juce::String(x) + "," + juce::String(y) + ","
+                             + juce::String::charToString(cell.note) + ","
+                             + juce::String((int)cell.channel) + ","
+                             + juce::String((int)cell.octave) + ","
+                             + juce::String(cell.locked ? 1 : 0);
+                }
+            }
+        }
+        xml->setAttribute("lifeCells", lifeStr);
+        xml->setAttribute("lifeScale", (int)engine.lifeGrid.currentScale);
+        xml->setAttribute("lifeRoot", engine.lifeGrid.rootNote);
+        xml->setAttribute("lifeRate", engine.lifeGrid.evolveRate);
+        xml->setAttribute("lifePulse", engine.lifeGrid.pulseMode ? 1 : 0);
+    }
+
+    // Save UDP/OSC config
+    xml->setAttribute("udpIP", udpTargetIP);
+    xml->setAttribute("udpPort", udpOutputPort);
+    xml->setAttribute("oscPort", oscOutputPort);
+
+    // Save APVTS state (all automatable parameters)
+    auto apvtsState = apvts.copyState();
+    xml->addChildElement(apvtsState.createXml().release());
+
     copyXmlToBinary(*xml, destData);
 }
 
@@ -248,7 +538,57 @@ void OrcaProcessor::setStateInformation(const void* data, int sizeInBytes) {
         int h = xml->getIntAttribute("h", 25);
         int f = xml->getIntAttribute("f", 0);
         auto gridStr = xml->getStringAttribute("grid");
-        engine.load(w, h, gridStr.toRawUTF8(), f);
+        {
+            const juce::SpinLock::ScopedLockType lock(engineLock);
+            engine.load(w, h, gridStr.toRawUTF8(), f);
+
+            // Restore Life mode state
+            engine.paintChannel = static_cast<uint8_t>(xml->getIntAttribute("paintChannel", 0));
+            engine.paintOctave = static_cast<uint8_t>(xml->getIntAttribute("paintOctave", 3));
+            if (xml->getIntAttribute("lifeMode", 0) == 1) {
+                engine.lifeMode = true;
+                engine.lifeGrid.resize(w, h);
+                auto lifeStr = xml->getStringAttribute("lifeCells", "");
+                if (lifeStr.isNotEmpty()) {
+                    auto cells = juce::StringArray::fromTokens(lifeStr, ";", "");
+                    for (auto& cellStr : cells) {
+                        auto vals = juce::StringArray::fromTokens(cellStr, ",", "");
+                        if (vals.size() >= 5) {
+                            int cx = vals[0].getIntValue();
+                            int cy = vals[1].getIntValue();
+                            char note = vals[2][0];
+                            int ch = vals[3].getIntValue();
+                            int oct = vals[4].getIntValue();
+                            int idx = engine.lifeGrid.indexAt(cx, cy);
+                            if (idx >= 0) {
+                                engine.lifeGrid.cells[idx].note = note;
+                                engine.lifeGrid.cells[idx].channel = static_cast<uint8_t>(ch);
+                                engine.lifeGrid.cells[idx].octave = static_cast<uint8_t>(oct);
+                                engine.lifeGrid.cells[idx].alive = true;
+                                engine.lifeGrid.cells[idx].locked = (vals.size() >= 6 && vals[5].getIntValue() != 0);
+                            }
+                        }
+                    }
+                }
+                // Legacy Life params (for old saves without APVTS)
+                engine.lifeGrid.currentScale = static_cast<orca::LifeGrid::ScaleType>(
+                    juce::jlimit(0, (int)orca::LifeGrid::NumScales - 1,
+                                 xml->getIntAttribute("lifeScale", 0)));
+                engine.lifeGrid.rootNote = juce::jlimit(0, 11, xml->getIntAttribute("lifeRoot", 0));
+                engine.lifeGrid.evolveRate = juce::jlimit(1, 32, xml->getIntAttribute("lifeRate", 4));
+                engine.lifeGrid.pulseMode = (xml->getIntAttribute("lifePulse", 0) != 0);
+            }
+        } // engineLock scope
+
+        // Restore APVTS state (overrides legacy params if present)
+        auto* apvtsXml = xml->getChildByName(apvts.state.getType());
+        if (apvtsXml)
+            apvts.replaceState(juce::ValueTree::fromXml(*apvtsXml));
+
+        // Sync restored APVTS values to engine so Life params match saved state
+        if (engine.lifeMode)
+            syncParamsToLifeGrid();
+
         editorWidth = xml->getIntAttribute("editorW", 800);
         editorHeight = xml->getIntAttribute("editorH", 600);
 
@@ -259,6 +599,17 @@ void OrcaProcessor::setStateInformation(const void* data, int sizeInBytes) {
         for (int i = 0; i < grooveLength; i++)
             grooves[i] = parts[i].getDoubleValue();
         grooveIndex = 0;
+
+        // Restore UDP/OSC config (lock protects juce::String from concurrent UI reads)
+        {
+            const juce::SpinLock::ScopedLockType lock(pendingLock);
+            udpTargetIP = xml->getStringAttribute("udpIP", "127.0.0.1");
+            udpOutputPort = xml->getIntAttribute("udpPort", 49161);
+            oscOutputPort = xml->getIntAttribute("oscPort", 49162);
+        }
+        // Reset sockets so they reconnect with new config on next use
+        udpSocket.reset();
+        oscSender.reset();
     }
 }
 

--- a/plugin/Source/PluginProcessor.cpp
+++ b/plugin/Source/PluginProcessor.cpp
@@ -22,6 +22,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout OrcaProcessor::createParamet
         juce::StringArray{"Off", "Forward", "Reverse", "Mirror", "Random"}, 0));
     timingGroup->addChild(std::make_unique<juce::AudioParameterBool>(
         juce::ParameterID("life_pulse", 1), "Pulse Mode", true));
+    timingGroup->addChild(std::make_unique<juce::AudioParameterBool>(
+        juce::ParameterID("life_conductor", 1), "Conductor Mode", false));
     layout.add(std::move(timingGroup));
 
     // ── Life: Pitch ──
@@ -44,6 +46,10 @@ juce::AudioProcessorValueTreeState::ParameterLayout OrcaProcessor::createParamet
     pitchGroup->addChild(std::make_unique<juce::AudioParameterChoice>(
         juce::ParameterID("life_chord", 1), "Chord Filter",
         juce::StringArray{"Off", "135", "1357", "125", "145", "1356", "12356", "1234567"}, 0));
+    pitchGroup->addChild(std::make_unique<juce::AudioParameterBool>(
+        juce::ParameterID("life_microtune", 1), "Microtuning", false));
+    pitchGroup->addChild(std::make_unique<juce::AudioParameterInt>(
+        juce::ParameterID("life_microtune_amt", 1), "Microtune Amount", 0, 100, 50));
     layout.add(std::move(pitchGroup));
 
     // ── Life: Dynamics ──
@@ -98,6 +104,9 @@ OrcaProcessor::OrcaProcessor()
     lifeRootParam    = dynamic_cast<juce::AudioParameterChoice*>(apvts.getParameter("life_root"));
     lifePulseParam   = dynamic_cast<juce::AudioParameterBool*>  (apvts.getParameter("life_pulse"));
     lifeRuleParam    = dynamic_cast<juce::AudioParameterChoice*>(apvts.getParameter("life_rule"));
+    lifeConductorParam = dynamic_cast<juce::AudioParameterBool*>(apvts.getParameter("life_conductor"));
+    lifeMicrotuneParam = dynamic_cast<juce::AudioParameterBool*>(apvts.getParameter("life_microtune"));
+    lifeMicrotuneAmtParam = dynamic_cast<juce::AudioParameterInt*>(apvts.getParameter("life_microtune_amt"));
 
     // Create virtual MIDI port via CoreMIDI C API (bypasses JUCE's broken singleton)
     midiClient = 0;
@@ -128,6 +137,9 @@ void OrcaProcessor::syncParamsToLifeGrid() {
     lg.maxOctave    = lifeMaxOctParam->get();
     if (lg.minOctave > lg.maxOctave) lg.minOctave = lg.maxOctave;
     lg.pulseMode    = lifePulseParam->get();
+    lg.conductorMode = lifeConductorParam->get();
+    lg.microtuning  = lifeMicrotuneParam->get();
+    lg.microtuneAmount = lifeMicrotuneAmtParam->get();
     lg.currentScale = static_cast<orca::LifeGrid::ScaleType>(lifeScaleParam->getIndex());
     lg.rootNote     = lifeRootParam->getIndex();
 
@@ -234,6 +246,15 @@ void OrcaProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuf
     // Sync Life mode parameters from APVTS → engine
     if (engine.lifeMode)
         syncParamsToLifeGrid();
+
+    // Conductor mode: scan incoming MIDI for NoteOn to trigger evolution
+    if (engine.lifeMode && engine.lifeGrid.conductorMode) {
+        for (const auto metadata : midiMessages) {
+            auto msg = metadata.getMessage();
+            if (msg.isNoteOn())
+                engine.lifeGrid.conductorTrigger.store(true, std::memory_order_relaxed);
+        }
+    }
 
     // Get DAW transport state
     double bpm = 120.0;

--- a/plugin/Source/PluginProcessor.h
+++ b/plugin/Source/PluginProcessor.h
@@ -61,6 +61,9 @@ public:
     juce::AudioParameterChoice* lifeRootParam     = nullptr;
     juce::AudioParameterBool*   lifePulseParam    = nullptr;
     juce::AudioParameterChoice* lifeRuleParam     = nullptr;
+    juce::AudioParameterBool*   lifeConductorParam = nullptr;
+    juce::AudioParameterBool*   lifeMicrotuneParam = nullptr;
+    juce::AudioParameterInt*    lifeMicrotuneAmtParam = nullptr;
 
     float lastShuffleValue = 100.0f;
 

--- a/plugin/Source/PluginProcessor.h
+++ b/plugin/Source/PluginProcessor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_osc/juce_osc.h>
 #include <atomic>
 #include <CoreMIDI/CoreMIDI.h>
 #include "engine/Engine.h"
@@ -38,6 +39,31 @@ public:
 
     orca::Engine engine;
 
+    // ── AudioProcessorValueTreeState ──
+    juce::AudioProcessorValueTreeState apvts;
+    static juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
+
+    // Cached raw pointers for fast audio-thread reads
+    juce::AudioParameterFloat*  shuffleParam     = nullptr;
+    juce::AudioParameterInt*    lifeRateParam     = nullptr;
+    juce::AudioParameterBool*   lifeDecayParam    = nullptr;
+    juce::AudioParameterInt*    lifeMinVelParam   = nullptr;
+    juce::AudioParameterInt*    lifeMinProbParam  = nullptr;
+    juce::AudioParameterInt*    lifeMaxNotesParam = nullptr;
+    juce::AudioParameterChoice* lifeSeqParam      = nullptr;
+    juce::AudioParameterBool*   lifeLockOctParam  = nullptr;
+    juce::AudioParameterChoice* lifeChordParam    = nullptr;
+    juce::AudioParameterBool*   lifeDedupParam    = nullptr;
+    juce::AudioParameterInt*    lifeDedupCCParam  = nullptr;
+    juce::AudioParameterInt*    lifeMinOctParam   = nullptr;
+    juce::AudioParameterInt*    lifeMaxOctParam   = nullptr;
+    juce::AudioParameterChoice* lifeScaleParam    = nullptr;
+    juce::AudioParameterChoice* lifeRootParam     = nullptr;
+    juce::AudioParameterBool*   lifePulseParam    = nullptr;
+    juce::AudioParameterChoice* lifeRuleParam     = nullptr;
+
+    float lastShuffleValue = 100.0f;
+
     // Virtual MIDI output via CoreMIDI (bypasses JUCE's broken singleton)
     MIDIClientRef midiClient = 0;
     MIDIEndpointRef midiEndpoint = 0;
@@ -46,6 +72,7 @@ public:
     // Debug: count MIDI events for UI display
     std::atomic<int> midiNoteOnCount { 0 };
     std::atomic<int> lastNoteOnPitch { -1 };
+    std::atomic<int> udpSendCount { 0 };
 
     // Persisted editor window size
     int editorWidth = 800, editorHeight = 600;
@@ -54,19 +81,84 @@ public:
     static constexpr int kMaxGrooveSlots = 16;
     double grooves[kMaxGrooveSlots] = { 1.0 };
     int grooveLength = 1;
-    int grooveIndex = 0;  // current position in groove cycle (accumulator path)
+    int grooveIndex = 0;
     void setGroove(const double* ratios, int count);
 
-    // DAW-exposed shuffle parameter (0-200%, 100=straight)
-    juce::AudioParameterFloat* shuffleParam = nullptr;
-    float lastShuffleValue = 100.0f; // track changes (default = center/straight)
+    // ── Thread-safe pending message queues ──
+    juce::SpinLock pendingLock;
+    juce::SpinLock engineLock;
+    std::atomic<bool> transportRunning { false };
+    std::atomic<bool> standalonePlay { false };
+
+    // Pending MIDI events from Life mode transitions (UI thread → audio thread)
+    static constexpr int kMaxPendingLifeEvents = 64;
+    orca::MidiEvent pendingLifeEvents[kMaxPendingLifeEvents];
+    int pendingLifeEventCount = 0;
+
+    void pushLifeEvent(const orca::MidiEvent& e) {
+        const juce::SpinLock::ScopedLockType lock(pendingLock);
+        if (pendingLifeEventCount < kMaxPendingLifeEvents)
+            pendingLifeEvents[pendingLifeEventCount++] = e;
+    }
+
+    // Pending commands from $ operator (audio thread → UI thread)
+    static constexpr int kMaxPendingCommands = 16;
+    static constexpr int kMaxPendingCommandLen = 64;
+    char pendingCommands[kMaxPendingCommands][kMaxPendingCommandLen];
+    int pendingCommandCount = 0;
+
+    // Pending UDP messages (audio thread → UI thread)
+    static constexpr int kMaxPendingUdp = 16;
+    static constexpr int kMaxPendingUdpLen = 64;
+    char pendingUdp[kMaxPendingUdp][kMaxPendingUdpLen];
+    int pendingUdpCount = 0;
+
+    // Pending OSC messages (audio thread → UI thread)
+    struct PendingOscMsg {
+        char path;
+        char data[63];
+        int dataLen;
+    };
+    static constexpr int kMaxPendingOsc = 16;
+    PendingOscMsg pendingOsc[kMaxPendingOsc];
+    int pendingOscCount = 0;
+
+    // UDP output
+    juce::String udpTargetIP { "127.0.0.1" };
+    int udpOutputPort = 49161;
+    std::unique_ptr<juce::DatagramSocket> udpSocket;
+
+    // OSC output
+    int oscOutputPort = 49162;
+    std::unique_ptr<juce::OSCSender> oscSender;
+
+    void setupUdpSocket();
+
+    // ── Helpers for Commander → APVTS sync ──
+    // Chord degree presets (must match createParameterLayout order)
+    static constexpr const char* chordPresets[] = {
+        "off", "135", "1357", "125", "145", "1356", "12356", "1234567"
+    };
+    static constexpr int numChordPresets = 8;
+
+    static constexpr const char* rulePresets[] = {
+        "life", "highlife", "seeds", "daynight", "diamoeba",
+        "replicator", "2x2", "morley", "34life"
+    };
+    static constexpr int numRulePresets = 9;
+
+    // Find closest chord preset index for a degree string
+    int findChordPresetIndex(const juce::String& degrees) const;
 
 private:
     double currentSampleRate = 44100.0;
     int    currentBlockSize  = 512;
     double frameAccumulator  = 0.0;
     bool   wasPlaying        = false;
-    int    lastPpqFrame      = -1;  // last frame derived from PPQ
+    int    lastPpqFrame      = -1;
+
+    // Sync APVTS params → lifeGrid fields (called from processBlock)
+    void syncParamsToLifeGrid();
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OrcaProcessor)
 };

--- a/plugin/Source/engine/Engine.h
+++ b/plugin/Source/engine/Engine.h
@@ -3,6 +3,7 @@
 #include "Grid.h"
 #include "Operator.h"
 #include "EngineIO.h"
+#include "LifeGrid.h"
 #include <cstdlib>
 #include <ctime>
 
@@ -12,6 +13,10 @@ class Engine {
 public:
     Grid grid;
     EngineIO io;
+    LifeGrid lifeGrid;
+    bool lifeMode = false;
+    uint8_t paintChannel = 0;
+    uint8_t paintOctave = 3;
 
     // Shadow buffer for thread-safe UI reads
     char shadowCells[kMaxGridSize];
@@ -21,6 +26,7 @@ public:
     char shadowPortOwner[kMaxGridSize];
     uint8_t shadowPortIdx[kMaxGridSize];
     bool shadowLocks[kMaxGridSize];
+    LifeCell shadowLife[kMaxGridSize];
     int shadowW = 0, shadowH = 0, shadowF = 0;
 
     Engine() {
@@ -42,6 +48,11 @@ public:
 
     // Execute one frame. Returns MIDI events.
     int step(MidiEvent* outEvents, int maxEvents) {
+        if (lifeMode) {
+            int count = lifeGrid.step(outEvents, maxEvents);
+            updateShadow();
+            return count;
+        }
         io.clear();
         grid.run();
         int count = io.run(outEvents, maxEvents);
@@ -49,9 +60,67 @@ public:
         return count;
     }
 
-    void updateShadow() {
-        // Re-parse operators so port info is always up-to-date (even when stopped)
-        grid.parse();
+    void enterLifeMode() {
+        lifeMode = true;
+        lifeGrid.resize(grid.w, grid.h);
+        // Convert existing letter cells to alive LifeCells
+        for (int y = 0; y < grid.h; y++) {
+            for (int x = 0; x < grid.w; x++) {
+                int idx = x + grid.w * y;
+                char g = grid.cells[idx];
+                if (isLetter(g)) {
+                    lifeGrid.cells[idx].note = g;
+                    lifeGrid.cells[idx].channel = paintChannel;
+                    lifeGrid.cells[idx].octave = paintOctave;
+                    lifeGrid.cells[idx].alive = true;
+                }
+            }
+        }
+    }
+
+    void exitLifeMode(MidiEvent* outEvents, int maxEvents, int& eventCount) {
+        // Silence all Life notes
+        eventCount += lifeGrid.silence(outEvents + eventCount, maxEvents - eventCount);
+        // Copy Life state back to grid
+        for (int y = 0; y < grid.h; y++) {
+            for (int x = 0; x < grid.w; x++) {
+                int idx = x + grid.w * y;
+                grid.cells[idx] = lifeGrid.cells[idx].alive ? lifeGrid.cells[idx].note : '.';
+            }
+        }
+        lifeMode = false;
+    }
+
+    void updateShadow(bool skipParse = false) {
+        if (lifeMode) {
+            // Use wrap dimensions for display (visible area)
+            int dispW = lifeGrid.wrapW;
+            int dispH = lifeGrid.wrapH;
+            int dispSize = dispW * dispH;
+            // Copy only the visible portion (storage may be larger)
+            for (int y = 0; y < dispH; y++) {
+                for (int x = 0; x < dispW; x++) {
+                    int si = x + dispW * y;  // shadow index
+                    int li = x + lifeGrid.w * y;  // storage index
+                    shadowLife[si] = lifeGrid.cells[li];
+                    shadowCells[si] = lifeGrid.cells[li].alive ? lifeGrid.cells[li].note : '.';
+                }
+            }
+            memset(shadowLocks, 0, dispSize * sizeof(bool));
+            memset(shadowPorts, 0, dispSize);
+            memset(shadowPortOwner, 0, dispSize);
+            memset(shadowPortIdx, 0, dispSize);
+            shadowW = dispW;
+            shadowH = dispH;
+            shadowF = lifeGrid.generation;
+            return;
+        }
+
+        // Re-parse operators so port info is always up-to-date (even when stopped).
+        // Skip during playback — step() already runs parse via grid.run(),
+        // and calling parse() from the UI thread would race with the audio thread.
+        if (!skipParse)
+            grid.parse();
 
         int size = grid.w * grid.h;
         memcpy(shadowCells, grid.cells, size);

--- a/plugin/Source/engine/EngineIO.h
+++ b/plugin/Source/engine/EngineIO.h
@@ -43,6 +43,61 @@ public:
         midi.silence(outEvents, maxEvents, eventCount);
         mono.silence(outEvents, maxEvents, eventCount);
     }
+
+    // Command queue for $ (self) operator
+    static constexpr int kMaxCommands = 16;
+    static constexpr int kMaxCommandLen = 64;
+    char commands[kMaxCommands][kMaxCommandLen];
+    int commandCount = 0;
+
+    void pushCommand(const char* cmd, int len) {
+        if (commandCount >= kMaxCommands) return;
+        int n = (len < kMaxCommandLen - 1) ? len : kMaxCommandLen - 1;
+        for (int i = 0; i < n; i++) commands[commandCount][i] = cmd[i];
+        commands[commandCount][n] = '\0';
+        commandCount++;
+    }
+
+    void clearCommands() { commandCount = 0; }
+
+    // UDP message queue for ; operator
+    static constexpr int kMaxUdpMessages = 16;
+    static constexpr int kMaxUdpLen = 64;
+    char udpMessages[kMaxUdpMessages][kMaxUdpLen];
+    int udpCount = 0;
+
+    void pushUdp(const char* msg, int len) {
+        if (udpCount >= kMaxUdpMessages) return;
+        int n = (len < kMaxUdpLen - 1) ? len : kMaxUdpLen - 1;
+        for (int i = 0; i < n; i++) udpMessages[udpCount][i] = msg[i];
+        udpMessages[udpCount][n] = '\0';
+        udpCount++;
+    }
+
+    void clearUdp() { udpCount = 0; }
+
+    // OSC message queue for = operator
+    static constexpr int kMaxOscMessages = 16;
+    static constexpr int kMaxOscLen = 64;
+    struct OscMessage {
+        char path;       // single char path (prepended with '/')
+        char data[63];   // message data (values)
+        int dataLen;
+    };
+    OscMessage oscMessages[kMaxOscMessages];
+    int oscCount = 0;
+
+    void pushOsc(char path, const char* data, int len) {
+        if (oscCount >= kMaxOscMessages) return;
+        auto& m = oscMessages[oscCount];
+        m.path = path;
+        m.dataLen = (len < 62) ? len : 62;
+        for (int i = 0; i < m.dataLen; i++) m.data[i] = data[i];
+        m.data[m.dataLen] = '\0';
+        oscCount++;
+    }
+
+    void clearOsc() { oscCount = 0; }
 };
 
 } // namespace orca

--- a/plugin/Source/engine/LifeGrid.h
+++ b/plugin/Source/engine/LifeGrid.h
@@ -2,6 +2,8 @@
 
 #include "Types.h"
 #include "Transpose.h"
+#include <atomic>
+#include <memory>
 
 namespace orca {
 
@@ -13,6 +15,7 @@ struct LifeCell {
     bool locked = false;   // protected from GoL death rules
     bool fired = false;    // triggered a note this step (for UI flash)
     uint16_t age = 0;      // generations survived (0 = just born)
+    uint8_t neighborCount = 0; // neighbor count at last evolution (for microtuning)
 };
 
 // Classic GoL pattern definitions
@@ -334,7 +337,7 @@ public:
             activeNotes[i] = { 0, 0, false };
         }
         generation = 0;
-        frameCounter = 0;
+        frameCounter = evolveRate - 1;
         hasInitialState = false;
     }
 
@@ -594,7 +597,7 @@ public:
     int minOctave = 0;   // lower octave limit (0-based)
     int maxOctave = 7;   // upper octave limit (0-based)
     int evolveRate = 4;  // evolve every N frames, power-of-2 (1,2,4,8,16,32)
-    int frameCounter = 0;
+    int frameCounter = 3; // default to evolveRate-1 so first frame hits cycle boundary
     bool pulseMode = true;  // false=hold (note-on at birth, note-off at death), true=pulse (retrigger every step)
     bool decay = false;           // unified age system: velocity drops + probability drops with age
     uint8_t minVelocity = 40;    // floor velocity for newborn cells (1-127)
@@ -672,7 +675,8 @@ public:
                 vel = juce::jmin(127, static_cast<int>(vel + boost));
             }
 
-            // Emit NoteOn
+            // Emit PitchBend + NoteOn
+            eventCount += emitPitchBend(m.channel, m.firstCellIndex, outEvents + eventCount, maxEvents - eventCount);
             if (eventCount < maxEvents) {
                 auto& e = outEvents[eventCount++];
                 e.type = MidiEvent::NoteOn;
@@ -791,6 +795,28 @@ public:
         return notesFiredPerChannel[channel & 0x0F] < maxNotes;
     }
 
+    // Microtuning: emit PitchBend before a NoteOn based on cell's neighbor count
+    // Stable cells (2 neighbors) = center, struggling cells (1 or 3) = detuned
+    int emitPitchBend(uint8_t channel, int cellIndex, MidiEvent* outEvents, int maxEvents) {
+        if (!microtuning || microtuneAmount == 0 || maxEvents < 1) return 0;
+        int neighbors = (cellIndex >= 0 && cellIndex < w * h) ? cells[cellIndex].neighborCount : 2;
+        int deviation = neighbors - 2; // 2 = stable center
+        // Scale: amount 100 = 1 semitone of max bend per deviation unit
+        // PitchBend: 0-16383, center=8192, typically ±2 semitones
+        // So 1 semitone = 4096 units. deviation*amount/100 semitones.
+        int bendOffset = deviation * microtuneAmount * 4096 / 100;
+        int bend = 8192 + bendOffset;
+        if (bend < 0) bend = 0;
+        if (bend > 16383) bend = 16383;
+        auto& e = outEvents[0];
+        e.type = MidiEvent::PitchBend;
+        e.bytes[0] = static_cast<uint8_t>(0xE0 + (channel & 0x0F));
+        e.bytes[1] = static_cast<uint8_t>(bend & 0x7F);        // LSB
+        e.bytes[2] = static_cast<uint8_t>((bend >> 7) & 0x7F);  // MSB
+        e.numBytes = 3;
+        return 1;
+    }
+
     // Row phase offset: stagger note emission across the evolve cycle by row
     enum SeqMode { SeqOff = 0, SeqForward, SeqReverse, SeqMirror, SeqRandom };
     SeqMode seqMode = SeqOff;
@@ -813,6 +839,14 @@ public:
     }
 
     bool lockOctave = false; // born cells inherit parent octave (no octave shifts from scale stepping)
+
+    // Conductor mode: manual evolution advancement
+    bool conductorMode = false;
+    std::atomic<bool> conductorTrigger { false };
+
+    // Microtuning: pitch bend per cell based on neighbor count
+    bool microtuning = false;
+    int microtuneAmount = 50; // 0-100, percentage of max detune
     // Chord degree filter: which scale degrees are allowed (1-indexed, stored as 0-indexed bitmask)
     // e.g. "135" = root+3rd+5th, "1357" = seventh chord, "0" or empty = off
     int chordDegrees[7] = { 0, 2, 4 }; // default: 1st, 3rd, 5th (stored as 0-indexed)
@@ -908,6 +942,8 @@ public:
             // Per-phase maxNotes check
             if (maxNotes > 0 && phaseNotesPerCh[pn.channel & 0x0F] >= maxNotes) continue;
 
+            eventCount += emitPitchBend(pn.channel, pn.cellIndex, outEvents + eventCount, maxEvents - eventCount);
+            if (eventCount >= maxEvents) break;
             auto& e = outEvents[eventCount++];
             e.type = MidiEvent::NoteOn;
             e.bytes[0] = static_cast<uint8_t>(0x90 + pn.channel);
@@ -932,6 +968,7 @@ public:
         uint8_t remaining;  // notes left to fire (including current)
         bool activeNote;    // is a note currently sounding from this ratchet?
         uint8_t velocity;   // velocity for ratchet notes
+        int cellIndex;      // source cell index (for microtuning PitchBend lookup)
     };
     Ratchet ratchets[kMaxRatchets];
     int ratchetCount = 0;
@@ -941,9 +978,48 @@ public:
         int eventCount = 0;
 
         // Only evolve every N frames
+        // In conductor mode: seq scanning cycles normally at evolveRate,
+        // but GoL rules fire immediately on conductorTrigger (any frame)
+        // without resetting the seq cycle.
         frameCounter++;
-        if (frameCounter < evolveRate) {
-            // Process pending ratchets and phase-scheduled notes on intermediate frames
+        bool conductorFired = conductorMode &&
+            conductorTrigger.exchange(false, std::memory_order_relaxed);
+        bool atCycleBoundary = (frameCounter >= evolveRate);
+
+        // Mid-cycle conductor trigger: evolve grid only, don't disturb seq cycle
+        if (conductorFired && !atCycleBoundary) {
+            memcpy(buffer, cells, sizeof(LifeCell) * w * h);
+            for (int y = 0; y < wrapH; y++) {
+                for (int x = 0; x < wrapW; x++) {
+                    int idx = x + w * y;
+                    int neighbors = countNeighbors(x, y);
+                    bool wasAlive = buffer[idx].alive;
+                    cells[idx].neighborCount = static_cast<uint8_t>(neighbors);
+                    if (wasAlive) {
+                        if (!shouldSurvive(neighbors) && !buffer[idx].locked) {
+                            cells[idx].alive = false;
+                            cells[idx].note = '.';
+                            cells[idx].age = 0;
+                        } else if (decay) {
+                            cells[idx].age = buffer[idx].age + 1;
+                        }
+                    } else if (shouldBeBorn(neighbors)) {
+                        LifeCell born = deriveBirthCell(x, y);
+                        born.age = 0;
+                        cells[idx] = born;
+                    }
+                }
+            }
+            // Continue with normal intermediate frame processing
+            eventCount += processRatchets(outEvents, maxEvents);
+            if (seqMode != SeqOff)
+                eventCount += processPhaseNotes(frameCounter, outEvents + eventCount, maxEvents - eventCount);
+            generation++;
+            return eventCount;
+        }
+
+        if (!atCycleBoundary) {
+            // Normal intermediate frame: process pending ratchets and phase notes
             eventCount += processRatchets(outEvents, maxEvents);
             if (seqMode != SeqOff)
                 eventCount += processPhaseNotes(frameCounter, outEvents + eventCount, maxEvents - eventCount);
@@ -951,6 +1027,7 @@ public:
             return eventCount;
         }
         frameCounter = 0;
+        bool shouldEvolve = conductorMode ? conductorFired : true;
         memset(notesFiredPerChannel, 0, sizeof(notesFiredPerChannel));
         phaseNoteCount = 0;
         preEmitCount = 0;
@@ -965,52 +1042,63 @@ public:
         eventCount += silenceRatchets(outEvents + eventCount, maxEvents - eventCount);
         ratchetCount = 0;
 
+        // Generation loop: playback mode replaces evolution
+        if (loopState == LoopPlaying) {
+            eventCount += loopPlayback(outEvents + eventCount, maxEvents - eventCount);
+            generation++;
+            return eventCount;
+        }
+
         // Auto-save initial state before first evolution
-        if (!hasInitialState && population() > 0)
+        if (shouldEvolve && !hasInitialState && population() > 0)
             saveInitialState();
 
-        // Snapshot current state
+        // Snapshot current state (needed for neighbor counting even without evolution)
         memcpy(buffer, cells, sizeof(LifeCell) * w * h);
 
-        // In pulse mode, silence all active notes before applying rules
+        // In pulse mode, silence all active notes before re-emitting
         if (pulseMode)
             eventCount += silence(outEvents + eventCount, maxEvents - eventCount);
 
-        // Apply GoL rules (only within visible/wrap boundary)
-        for (int y = 0; y < wrapH; y++) {
-            for (int x = 0; x < wrapW; x++) {
-                int idx = x + w * y;
-                int neighbors = countNeighbors(x, y);
-                bool wasAlive = buffer[idx].alive;
+        if (shouldEvolve) {
+            // Apply GoL rules (only within visible/wrap boundary)
+            for (int y = 0; y < wrapH; y++) {
+                for (int x = 0; x < wrapW; x++) {
+                    int idx = x + w * y;
+                    int neighbors = countNeighbors(x, y);
+                    bool wasAlive = buffer[idx].alive;
 
-                if (wasAlive) {
-                    if (!shouldSurvive(neighbors) && !buffer[idx].locked) {
-                        // Death (protected cells are immune)
-                        cells[idx].alive = false;
-                        cells[idx].note = '.';
-                        cells[idx].age = 0;
+                    cells[idx].neighborCount = static_cast<uint8_t>(neighbors);
 
-                        // Emit note-off (hold mode only; pulse already silenced above)
-                        if (!pulseMode && activeNotes[idx].active && eventCount < maxEvents) {
-                            auto& e = outEvents[eventCount++];
-                            e.type = MidiEvent::NoteOff;
-                            e.bytes[0] = static_cast<uint8_t>(0x80 + activeNotes[idx].channel);
-                            e.bytes[1] = activeNotes[idx].midiNote;
-                            e.bytes[2] = 0;
-                            e.numBytes = 3;
-                            activeNotes[idx].active = false;
+                    if (wasAlive) {
+                        if (!shouldSurvive(neighbors) && !buffer[idx].locked) {
+                            // Death (protected cells are immune)
+                            cells[idx].alive = false;
+                            cells[idx].note = '.';
+                            cells[idx].age = 0;
+
+                            // Emit note-off (hold mode only; pulse already silenced above)
+                            if (!pulseMode && activeNotes[idx].active && eventCount < maxEvents) {
+                                auto& e = outEvents[eventCount++];
+                                e.type = MidiEvent::NoteOff;
+                                e.bytes[0] = static_cast<uint8_t>(0x80 + activeNotes[idx].channel);
+                                e.bytes[1] = activeNotes[idx].midiNote;
+                                e.bytes[2] = 0;
+                                e.numBytes = 3;
+                                activeNotes[idx].active = false;
+                            }
+                        } else {
+                            // Survival — increment age
+                            if (decay)
+                                cells[idx].age = buffer[idx].age + 1;
                         }
                     } else {
-                        // Survival — increment age
-                        if (decay)
-                            cells[idx].age = buffer[idx].age + 1;
-                    }
-                } else {
-                    if (shouldBeBorn(neighbors)) {
-                        // Birth
-                        LifeCell born = deriveBirthCell(x, y);
-                        born.age = 0;
-                        cells[idx] = born;
+                        if (shouldBeBorn(neighbors)) {
+                            // Birth
+                            LifeCell born = deriveBirthCell(x, y);
+                            born.age = 0;
+                            cells[idx] = born;
+                        }
                     }
                 }
             }
@@ -1085,6 +1173,7 @@ public:
 
                     // Fire first ratchet note immediately
                     uint8_t vel = velocityFor(i);
+                    eventCount += emitPitchBend(cCh, i, outEvents + eventCount, maxEvents - eventCount);
                     if (eventCount < maxEvents) {
                         auto& e = outEvents[eventCount++];
                         e.type = MidiEvent::NoteOn;
@@ -1099,13 +1188,14 @@ public:
                     ratchets[ratchetCount++] = {
                         static_cast<uint8_t>(tr.id), cCh,
                         static_cast<uint8_t>(ratchetNotes - 1), // remaining after first
-                        true, vel
+                        true, vel, i
                     };
 
                     // Mark all cluster cells so they don't fire individually
                     // (clusterTag already marks them, we skip tagged cells below)
                 } else if (clusterSize == 1) {
                     // Single cell: fire normally
+                    eventCount += emitPitchBend(cCh, i, outEvents + eventCount, maxEvents - eventCount);
                     if (eventCount < maxEvents) {
                         auto& e = outEvents[eventCount++];
                         e.type = MidiEvent::NoteOn;
@@ -1155,6 +1245,7 @@ public:
                     // Density gate (phase-0 notes in seq mode, or all notes in normal mode)
                     if (!canFireMore(cells[i].channel)) continue;
 
+                    eventCount += emitPitchBend(cells[i].channel, i, outEvents + eventCount, maxEvents - eventCount);
                     if (eventCount < maxEvents) {
                         auto& e = outEvents[eventCount++];
                         e.type = MidiEvent::NoteOn;
@@ -1175,7 +1266,11 @@ public:
         if (dedup && preEmitCount > 0)
             eventCount += flushDedup(outEvents + eventCount, maxEvents - eventCount);
 
-        firstEvolution = false;
+        // Generation loop: record this evolution's state + events
+        if (shouldEvolve && loopState == LoopRecording)
+            loopRecord(outEvents, eventCount);
+
+        if (shouldEvolve) firstEvolution = false;
         generation++;
         return eventCount;
     }
@@ -1198,6 +1293,7 @@ public:
             }
 
             // Fire next ratchet note
+            eventCount += emitPitchBend(rch.channel, rch.cellIndex, outEvents + eventCount, maxEvents - eventCount);
             if (eventCount < maxEvents) {
                 auto& e = outEvents[eventCount++];
                 e.type = MidiEvent::NoteOn;
@@ -1295,11 +1391,125 @@ public:
                     cells[x + w * y] = initialState[x + initialW * y];
         }
         generation = 0;
-        frameCounter = 0;
+        frameCounter = evolveRate - 1;
         firstEvolution = true;
         phaseNoteCount = 0;
         mirrorForward = true;
         memset(notesFiredPerChannel, 0, sizeof(notesFiredPerChannel));
+        return eventCount;
+    }
+
+    // ── Generation Loop ──────────────────────────────────────────────────
+    enum LoopState { LoopOff = 0, LoopRecording, LoopPlaying };
+    LoopState loopState = LoopOff;
+    int loopLength = 0;      // target loop length (generations)
+    int loopHead = 0;        // current write/read position
+    int loopRecorded = 0;    // how many generations recorded so far
+
+    static constexpr int kMaxLoopGens = 64;
+    static constexpr int kMaxLoopEvents = 256;
+
+    struct LoopGeneration {
+        LifeCell cells[kMaxGridSize];
+        MidiEvent events[kMaxLoopEvents];
+        int eventCount = 0;
+        Ratchet ratchets[kMaxRatchets];
+        int ratchetCount = 0;
+        PhaseNote phaseNotes[kMaxPhaseNotes];
+        int phaseNoteCount = 0;
+        int wrapW = 0, wrapH = 0, storageW = 0;
+    };
+
+    std::unique_ptr<LoopGeneration[]> loopBuffer;
+
+    void armLoop(int length) {
+        int len = (length < 1) ? 1 : (length > kMaxLoopGens ? kMaxLoopGens : length);
+        loopBuffer.reset(new LoopGeneration[len]);
+        loopLength = len;
+        loopHead = 0;
+        loopRecorded = 0;
+        loopState = LoopRecording;
+    }
+
+    void stopLoop() {
+        loopState = LoopOff;
+        loopBuffer.reset();
+        loopLength = 0;
+        loopHead = 0;
+        loopRecorded = 0;
+    }
+
+    void startLoopPlayback() {
+        if (loopRecorded > 0 && loopBuffer) {
+            loopState = LoopPlaying;
+            loopHead = 0;
+        }
+    }
+
+    // Called at end of evolution in step() — snapshot current state
+    void loopRecord(const MidiEvent* events, int eventCount) {
+        if (loopState != LoopRecording || !loopBuffer || loopHead >= loopLength) return;
+        auto& gen = loopBuffer[loopHead];
+        // Store grid snapshot with current dimensions
+        for (int y = 0; y < wrapH; y++)
+            for (int x = 0; x < wrapW; x++)
+                gen.cells[x + wrapW * y] = cells[x + w * y];
+        gen.wrapW = wrapW;
+        gen.wrapH = wrapH;
+        gen.storageW = w;
+        // Store emitted events
+        gen.eventCount = (eventCount < kMaxLoopEvents) ? eventCount : kMaxLoopEvents;
+        for (int i = 0; i < gen.eventCount; i++)
+            gen.events[i] = events[i];
+        // Store ratchets and phase notes for inter-frame replay
+        gen.ratchetCount = (ratchetCount < kMaxRatchets) ? ratchetCount : kMaxRatchets;
+        for (int i = 0; i < gen.ratchetCount; i++)
+            gen.ratchets[i] = ratchets[i];
+        gen.phaseNoteCount = (phaseNoteCount < kMaxPhaseNotes) ? phaseNoteCount : kMaxPhaseNotes;
+        for (int i = 0; i < gen.phaseNoteCount; i++)
+            gen.phaseNotes[i] = phaseNotes[i];
+
+        loopHead++;
+        loopRecorded = loopHead;
+        if (loopHead >= loopLength) {
+            loopState = LoopPlaying;
+            loopHead = 0;
+        }
+    }
+
+    // Called at evolution time when loop is playing — restore state + replay events
+    int loopPlayback(MidiEvent* outEvents, int maxEvents) {
+        if (!loopBuffer || loopRecorded == 0) return 0;
+        auto& gen = loopBuffer[loopHead];
+
+        // Silence current active notes
+        int eventCount = silence(outEvents, maxEvents);
+
+        // Restore grid from snapshot
+        for (int i = 0; i < w * h; i++)
+            cells[i] = LifeCell();
+        int copyW = (gen.wrapW < wrapW) ? gen.wrapW : wrapW;
+        int copyH = (gen.wrapH < wrapH) ? gen.wrapH : wrapH;
+        for (int y = 0; y < copyH; y++)
+            for (int x = 0; x < copyW; x++)
+                cells[x + w * y] = gen.cells[x + gen.wrapW * y];
+
+        // Replay stored events
+        int eventsToReplay = (gen.eventCount < (maxEvents - eventCount)) ? gen.eventCount : (maxEvents - eventCount);
+        for (int i = 0; i < eventsToReplay; i++)
+            outEvents[eventCount++] = gen.events[i];
+
+        // Restore ratchets and phase notes for intermediate frame processing
+        ratchetCount = gen.ratchetCount;
+        for (int i = 0; i < ratchetCount; i++)
+            ratchets[i] = gen.ratchets[i];
+        phaseNoteCount = gen.phaseNoteCount;
+        for (int i = 0; i < phaseNoteCount; i++)
+            phaseNotes[i] = gen.phaseNotes[i];
+
+        // Advance read head
+        loopHead = (loopHead + 1) % loopRecorded;
+
         return eventCount;
     }
 

--- a/plugin/Source/engine/LifeGrid.h
+++ b/plugin/Source/engine/LifeGrid.h
@@ -1,0 +1,1320 @@
+#pragma once
+
+#include "Types.h"
+#include "Transpose.h"
+
+namespace orca {
+
+struct LifeCell {
+    char note = '.';       // note letter or '.' if dead
+    uint8_t channel = 0;   // MIDI channel 0-15
+    uint8_t octave = 3;    // octave 0..maxOctave
+    bool alive = false;
+    bool locked = false;   // protected from GoL death rules
+    bool fired = false;    // triggered a note this step (for UI flash)
+    uint16_t age = 0;      // generations survived (0 = just born)
+};
+
+// Classic GoL pattern definitions
+struct LifePattern {
+    const char* name;
+    int w, h;
+    const char* data; // '.' = dead, 'X' = alive, row-major
+};
+
+// Built-in pattern library — grouped by category (indices must be contiguous per category)
+static const LifePattern builtInPatterns[] = {
+    // ── Still Lifes (0-10) ──
+    { "Block",      2, 2, "XX"
+                          "XX" },
+    { "Beehive",    4, 3, ".XX."
+                          "X..X"
+                          ".XX." },
+    { "Loaf",       4, 4, ".XX."
+                          "X..X"
+                          ".X.X"
+                          "..X." },
+    { "Boat",       3, 3, "XX."
+                          "X.X"
+                          ".X." },
+    { "Tub",        3, 3, ".X."
+                          "X.X"
+                          ".X." },
+    { "Pond",       4, 4, ".XX."
+                          "X..X"
+                          "X..X"
+                          ".XX." },
+    { "Ship",       3, 3, "XX."
+                          "X.X"
+                          ".XX" },
+    { "Long Boat",  4, 4, ".X.."
+                          "X.X."
+                          ".X.X"
+                          "..XX" },
+    { "Barge",      4, 4, ".X.."
+                          "X.X."
+                          ".X.X"
+                          "..X." },
+    { "Mango",      5, 4, ".XX.."
+                          "X..X."
+                          ".X..X"
+                          "..XX." },
+    { "Eater 1",    4, 4, "XX.."
+                          "X.X."
+                          "..X."
+                          "..XX" },
+
+    // ── Oscillators (11-24) ──
+    { "Blinker",    3, 1, "XXX" },
+    { "Toad",       4, 2, ".XXX"
+                          "XXX." },
+    { "Beacon",     4, 4, "XX.."
+                          "XX.."
+                          "..XX"
+                          "..XX" },
+    { "Pulsar",    13, 13,
+        "..XXX...XXX.."
+        "............."
+        "X....X.X....X"
+        "X....X.X....X"
+        "X....X.X....X"
+        "..XXX...XXX.."
+        "............."
+        "..XXX...XXX.."
+        "X....X.X....X"
+        "X....X.X....X"
+        "X....X.X....X"
+        "............."
+        "..XXX...XXX.." },
+    { "Pentadecathlon", 10, 3,
+        "..X....X.."
+        "XX.XXXX.XX"
+        "..X....X.." },
+    { "Clock",      4, 4, "..X."
+                          "X.X."
+                          ".X.X"
+                          ".X.." },
+    { "Octagon 2", 8, 8,
+        "...XX..."
+        "..X..X.."
+        ".X....X."
+        "X......X"
+        "X......X"
+        ".X....X."
+        "..X..X.."
+        "...XX..." },
+    { "Figure 8",  6, 6,
+        "XXX..."
+        "XXX..."
+        "XXX..."
+        "...XXX"
+        "...XXX"
+        "...XXX" },
+    { "Tumbler",   9, 5,
+        ".X.....X."
+        "X.X...X.X"
+        "X..X.X..X"
+        "..X...X.."
+        "..XX.XX.." },
+    { "Fumarole",  8, 7,
+        "...XX..."
+        ".X....X."
+        ".X....X."
+        ".X....X."
+        "..X..X.."
+        "X.X..X.X"
+        "XX....XX" },
+
+    { "Queen Bee Shuttle", 22, 7,
+        ".........XX..........."
+        ".........X.X.........."
+        "....XX......X........."
+        "XX.X..X..X..X.......XX"
+        "XX..XX......X.......XX"
+        ".........X.X.........."
+        ".........XX..........." },
+    { "Twin Bees Shuttle", 29, 11,
+        ".................X..........."
+        "XX...............XX........XX"
+        "XX................XX.......XX"
+        ".............XX..XX.........."
+        "............................."
+        "............................."
+        "............................."
+        ".............XX..XX.........."
+        "XX................XX.......XX"
+        "XX...............XX........XX"
+        ".................X..........." },
+    { "Ants",            44, 4,
+        "XX...XX...XX...XX...XX...XX...XX...XX...XX.."
+        "..XX...XX...XX...XX...XX...XX...XX...XX...XX"
+        "..XX...XX...XX...XX...XX...XX...XX...XX...XX"
+        "XX...XX...XX...XX...XX...XX...XX...XX...XX.." },
+    { "Turning Toads",   37, 8,
+        "...............X......X.............."
+        "..............XX.....XX......XX......"
+        "......XXX.X.X.XX.X.X.XX.X.X.........."
+        "..XX.X......X.X....X.X....X.X..X.XX.."
+        "X..X.X...X..................XXXX.X..X"
+        "XX.X.X...........................X.XX"
+        "...X.............................X..."
+        "...XX...........................XX..." },
+
+    // ── Spaceships (25-33) ──
+    { "Glider SE",  3, 3, ".X."
+                          "..X"
+                          "XXX" },
+    { "Glider SW",  3, 3, ".X."
+                          "X.."
+                          "XXX" },
+    { "Glider NE",  3, 3, "XXX"
+                          "..X"
+                          ".X." },
+    { "Glider NW",  3, 3, "XXX"
+                          "X.."
+                          ".X." },
+    { "LWSS",       5, 4, ".X..X"
+                          "X...."
+                          "X...X"
+                          ".XXXX" },
+    { "MWSS",       6, 5, "...X.."
+                          ".X...X"
+                          "X....."
+                          "X....X"
+                          ".XXXXX" },
+    { "HWSS",       7, 5, "...XX.."
+                          ".X....X"
+                          "X......"
+                          "X.....X"
+                          ".XXXXXX" },
+    { "Copperhead", 8, 12,
+        ".XX..XX."
+        "...XX..."
+        "...XX..."
+        "X.X..X.X"
+        "X......X"
+        "........"
+        "X......X"
+        ".XX..XX."
+        "..XXXX.."
+        "........"
+        "...XX..."
+        "...XX..." },
+    { "Loafer",    9, 9,
+        ".XX..X.XX"
+        "X..X..XX."
+        ".X.X....."
+        "..X......"
+        "........X"
+        "......XXX"
+        ".....X..."
+        "......X.."
+        ".......XX" },
+
+    // ── Methuselahs (34-42) ──
+    { "R-pentomino",3, 3, ".XX"
+                          "XX."
+                          ".X." },
+    { "Diehard",    8, 3, "......X."
+                          "XX......"
+                          ".X...XXX" },
+    { "Acorn",      7, 3, ".X....."
+                          "...X..."
+                          "XX..XXX" },
+    { "Pi",         3, 3, "XXX"
+                          "X.X"
+                          "X.X" },
+    { "B-heptomino",4, 3, "X.XX"
+                          "XXX."
+                          ".X.." },
+    { "Thunderbird",3, 5, "XXX"
+                          "..."
+                          ".X."
+                          ".X."
+                          ".X." },
+    { "Herschel",   3, 4, "X.."
+                          "XXX"
+                          "X.X"
+                          "..X" },
+    { "Rabbits",    7, 3, "X...XXX"
+                          "XXX..X."
+                          ".X....." },
+    { "Lidka",      9, 6,
+        "......X.."
+        "......XXX"
+        "........."
+        "...XX...X"
+        "...X....X"
+        "XXX.....X" },
+
+    // ── Guns (43-44) ──
+    { "Gosper Gun", 36, 9,
+        "........................X..........."
+        "......................X.X..........."
+        "............XX......XX............XX"
+        "...........X...X....XX............XX"
+        "XX........X.....X...XX.............."
+        "XX........X...X.XX....X.X..........."
+        "..........X.....X.......X..........."
+        "...........X...X...................."
+        "............XX......................" },
+
+    { "Simkin Gun",  33, 14,
+        "XX.....XX........................"
+        "XX.....XX........................"
+        "................................."
+        "....XX..........................."
+        "....XX..........................."
+        "................................."
+        "................................."
+        "................................."
+        "................................."
+        "......................XX.XX......"
+        ".....................X.....X....."
+        ".....................X......X..XX"
+        ".....................XXX...X...XX"
+        "..........................X......" },
+    { "Simkin Gun 1B", 33, 21,
+        "XX.....XX........................"
+        "XX.....XX........................"
+        "................................."
+        "....XX..........................."
+        "....XX..........................."
+        "................................."
+        "................................."
+        "................................."
+        "................................."
+        "......................XX.XX......"
+        ".....................X.....X....."
+        ".....................X......X..XX"
+        ".....................XXX...X...XX"
+        "..........................X......"
+        "................................."
+        "................................."
+        "................................."
+        "....................XX..........."
+        "....................X............"
+        ".....................XXX........."
+        ".......................X........." },
+
+
+    // ── Puffers (45-46) ──
+    { "Puffer 1", 18, 5,
+        ".XXX...........XXX"
+        "X..X..........X..X"
+        "...X....XX.....X.."
+        "...X...X..X....X.."
+        "..X....X......X..." },
+    { "Switchengine", 6, 4,
+        ".X.X.."
+        "X....."
+        ".X..X."
+        "...XXX" },
+};
+
+class LifeGrid {
+public:
+    LifeCell cells[kMaxGridSize];
+    LifeCell buffer[kMaxGridSize]; // snapshot for simultaneous update
+    int w = 25, h = 25;           // storage dimensions (never shrink)
+    int wrapW = 25, wrapH = 25;   // visible/wrap dimensions (toroidal boundary)
+    int generation = 0;
+
+    // Active notes for MIDI note-off tracking
+    struct ActiveNote {
+        uint8_t channel;
+        uint8_t midiNote; // MIDI pitch 0-127
+        bool active;
+    };
+    ActiveNote activeNotes[kMaxGridSize];
+
+    void clear() {
+        for (int i = 0; i < kMaxGridSize; i++) {
+            cells[i] = LifeCell();
+            activeNotes[i] = { 0, 0, false };
+        }
+        generation = 0;
+        frameCounter = 0;
+        hasInitialState = false;
+    }
+
+    void resize(int newW, int newH) {
+        w = newW;
+        h = newH;
+        wrapW = newW;
+        wrapH = newH;
+        clear();
+    }
+
+    // Update toroidal wrap boundary (storage stays the same, simulation wraps at view size)
+    void setWrapSize(int newWrapW, int newWrapH) {
+        // Grow storage if needed (never shrink)
+        if (newWrapW > w || newWrapH > h) {
+            int newW = newWrapW > w ? newWrapW : w;
+            int newH = newWrapH > h ? newWrapH : h;
+            LifeCell oldCells[kMaxGridSize];
+            ActiveNote oldNotes[kMaxGridSize];
+            int oldW = w, oldH = h;
+            memcpy(oldCells, cells, sizeof(LifeCell) * oldW * oldH);
+            memcpy(oldNotes, activeNotes, sizeof(ActiveNote) * oldW * oldH);
+
+            w = newW; h = newH;
+            for (int i = 0; i < w * h; i++) {
+                cells[i] = LifeCell();
+                activeNotes[i] = { 0, 0, false };
+            }
+            for (int y = 0; y < oldH; y++) {
+                for (int x = 0; x < oldW; x++) {
+                    cells[x + w * y] = oldCells[x + oldW * y];
+                    activeNotes[x + w * y] = oldNotes[x + oldW * y];
+                }
+            }
+        }
+        wrapW = newWrapW;
+        wrapH = newWrapH;
+    }
+
+    int indexAt(int x, int y) const {
+        if (x < 0 || x >= w || y < 0 || y >= h) return -1;
+        return x + w * y;
+    }
+
+    const LifeCell& cellAt(int x, int y) const {
+        int idx = indexAt(x, y);
+        if (idx < 0) {
+            static const LifeCell dead;
+            return dead;
+        }
+        return cells[idx];
+    }
+
+    // Count alive neighbors (8-directional, toroidal wrapping at visible boundary)
+    int countNeighbors(int x, int y) const {
+        int count = 0;
+        for (int dy = -1; dy <= 1; dy++) {
+            for (int dx = -1; dx <= 1; dx++) {
+                if (dx == 0 && dy == 0) continue;
+                int nx = (x + dx + wrapW) % wrapW;
+                int ny = (y + dy + wrapH) % wrapH;
+                if (buffer[nx + w * ny].alive) count++;
+            }
+        }
+        return count;
+    }
+
+    // Scale system for melodic evolution
+    enum ScaleType {
+        Chromatic, Major, Minor, Pentatonic, Dorian,
+        Phrygian, Lydian, Mixolydian, Locrian,
+        HarmonicMinor, MelodicMinor,
+        MinorPentatonic, Blues,
+        WholeTone, Diminished,
+        NumScales
+    };
+    ScaleType currentScale = Chromatic;
+    int rootNote = 0;  // 0=C, 1=C#, 2=D, ... 11=B
+
+    static constexpr int kMaxScaleNotes = 12;
+    static constexpr int scaleNotes[NumScales][kMaxScaleNotes] = {
+        {0,1,2,3,4,5,6,7,8,9,10,11},     // chromatic
+        {0,2,4,5,7,9,11,-1,-1,-1,-1,-1},  // major (ionian)
+        {0,2,3,5,7,8,10,-1,-1,-1,-1,-1},  // natural minor (aeolian)
+        {0,2,4,7,9,-1,-1,-1,-1,-1,-1,-1}, // pentatonic (major)
+        {0,2,3,5,7,9,10,-1,-1,-1,-1,-1},  // dorian
+        {0,1,3,5,7,8,10,-1,-1,-1,-1,-1},  // phrygian
+        {0,2,4,6,7,9,11,-1,-1,-1,-1,-1},  // lydian
+        {0,2,4,5,7,9,10,-1,-1,-1,-1,-1},  // mixolydian
+        {0,1,3,5,6,8,10,-1,-1,-1,-1,-1},  // locrian
+        {0,2,3,5,7,8,11,-1,-1,-1,-1,-1},  // harmonic minor
+        {0,2,3,5,7,9,11,-1,-1,-1,-1,-1},  // melodic minor
+        {0,3,5,7,10,-1,-1,-1,-1,-1,-1,-1},// minor pentatonic
+        {0,3,5,6,7,10,-1,-1,-1,-1,-1,-1}, // blues
+        {0,2,4,6,8,10,-1,-1,-1,-1,-1,-1}, // whole tone
+        {0,2,3,5,6,8,9,11,-1,-1,-1,-1},   // diminished (half-whole)
+    };
+    static constexpr int scaleLengths[NumScales] = {12, 7, 7, 5, 7, 7, 7, 7, 7, 7, 7, 5, 6, 6, 8};
+
+    static const char* scaleName(ScaleType s) {
+        switch (s) {
+            case Chromatic:      return "chromatic";
+            case Major:          return "major";
+            case Minor:          return "minor";
+            case Pentatonic:     return "pentatonic";
+            case Dorian:         return "dorian";
+            case Phrygian:       return "phrygian";
+            case Lydian:         return "lydian";
+            case Mixolydian:     return "mixolydian";
+            case Locrian:        return "locrian";
+            case HarmonicMinor:  return "harm.min";
+            case MelodicMinor:   return "mel.min";
+            case MinorPentatonic:return "min.penta";
+            case Blues:          return "blues";
+            case WholeTone:      return "wholetone";
+            case Diminished:     return "diminished";
+            default:             return "?";
+        }
+    }
+
+    // Semitone ↔ note char conversion (matches noteIndex: C=0,c=1,D=2,d=3,E=4,F=5,f=6,G=7,g=8,A=9,a=10,B=11)
+    static constexpr char semitoneToNote[12] = {'C','c','D','d','E','F','f','G','g','A','a','B'};
+
+    static const char* rootNoteName(int root) {
+        static const char* names[12] = {"C","C#","D","D#","E","F","F#","G","G#","A","A#","B"};
+        return names[root % 12];
+    }
+
+    static int noteToSemitone(char n) { return noteIndex(n); }
+
+    // Step a semitone value up or down within the current scale (relative to rootNote),
+    // returning new absolute semitone (0-11). Also adjusts octaveDelta for wrapping.
+    int stepInScale(int semitone, int direction, int& octaveDelta) const {
+        int sLen = scaleLengths[currentScale];
+        const int* s = scaleNotes[static_cast<int>(currentScale)];
+
+        // Convert absolute semitone to root-relative
+        int rel = ((semitone - rootNote) % 12 + 12) % 12;
+
+        // Find closest scale degree to this relative semitone
+        int bestDeg = 0;
+        int bestDist = 99;
+        for (int i = 0; i < sLen; i++) {
+            int dist = ((rel - s[i]) % 12 + 12) % 12;
+            if (dist < bestDist) { bestDist = dist; bestDeg = i; }
+            int dist2 = ((s[i] - rel) % 12 + 12) % 12;
+            if (dist2 < bestDist) { bestDist = dist2; bestDeg = i; }
+        }
+
+        int newDeg = bestDeg + direction;
+        octaveDelta = 0;
+        if (newDeg >= sLen) { newDeg = 0; octaveDelta = 1; }
+        else if (newDeg < 0) { newDeg = sLen - 1; octaveDelta = -1; }
+
+        // Convert back to absolute semitone
+        return (s[newDeg] + rootNote) % 12;
+    }
+
+    // Get neighbor cells that are alive (for birth note derivation)
+    struct NeighborInfo {
+        int x, y;
+        char note;
+        uint8_t channel;
+        uint8_t octave;
+    };
+
+    int getAliveNeighbors(int x, int y, NeighborInfo* out, int maxOut) const {
+        int count = 0;
+        for (int dy = -1; dy <= 1; dy++) {
+            for (int dx = -1; dx <= 1; dx++) {
+                if (dx == 0 && dy == 0) continue;
+                if (count >= maxOut) return count;
+                int nx = (x + dx + wrapW) % wrapW;
+                int ny = (y + dy + wrapH) % wrapH;
+                const auto& c = buffer[nx + w * ny];
+                if (c.alive) {
+                    out[count++] = { nx, ny, c.note, c.channel, c.octave };
+                }
+            }
+        }
+        return count;
+    }
+
+    // Derive birth note using directional scale-step evolution
+    LifeCell deriveBirthCell(int x, int y) const {
+        NeighborInfo neighbors[8];
+        int nCount = getAliveNeighbors(x, y, neighbors, 8);
+
+        LifeCell born;
+        born.alive = true;
+
+        if (nCount == 0) {
+            born.note = 'C';
+            born.channel = 0;
+            born.octave = 3;
+            return born;
+        }
+
+        // --- Directional note evolution ---
+        // 1. Compute centroid of parent positions
+        float cx = 0, cy = 0;
+        for (int i = 0; i < nCount; i++) { cx += neighbors[i].x; cy += neighbors[i].y; }
+        cx /= nCount; cy /= nCount;
+
+        // 2. Direction: born cell relative to centroid
+        float dx = x - cx;  // positive = born is right of parents
+        float dy = y - cy;  // positive = born is below parents
+        float dir = dx + dy; // combined directional signal
+        int step = (dir > 0.01f) ? 1 : (dir < -0.01f) ? -1 : 1; // default up to avoid stagnation
+
+        // 3. Get median parent note (by semitone, pick middle value)
+        int semitones[8];
+        int octaves[8];
+        for (int i = 0; i < nCount; i++) {
+            semitones[i] = noteToSemitone(neighbors[i].note);
+            octaves[i] = neighbors[i].octave;
+            if (semitones[i] < 0) semitones[i] = 0; // fallback for invalid notes
+        }
+        // Simple sort for median (nCount is at most 8)
+        for (int i = 0; i < nCount - 1; i++)
+            for (int j = i + 1; j < nCount; j++) {
+                int pitchI = octaves[i] * 12 + semitones[i];
+                int pitchJ = octaves[j] * 12 + semitones[j];
+                if (pitchJ < pitchI) {
+                    int ts = semitones[i]; semitones[i] = semitones[j]; semitones[j] = ts;
+                    int to = octaves[i]; octaves[i] = octaves[j]; octaves[j] = to;
+                }
+            }
+        int medIdx = nCount / 2;
+        int medSemitone = semitones[medIdx];
+        int medOctave = octaves[medIdx];
+
+        // 4. Step within scale
+        int octDelta = 0;
+        int newSemitone = stepInScale(medSemitone, step, octDelta);
+        int newOctave = lockOctave ? medOctave : clamp(medOctave + octDelta, minOctave, maxOctave);
+        born.note = semitoneToNote[newSemitone];
+        born.octave = static_cast<uint8_t>(newOctave);
+
+        // --- Channel: majority vote (unchanged) ---
+        int chCounts[16] = {};
+        for (int i = 0; i < nCount; i++)
+            chCounts[neighbors[i].channel]++;
+        uint8_t bestCh = neighbors[0].channel;
+        int bestChCount = 0;
+        for (int i = 0; i < 16; i++) {
+            if (chCounts[i] > bestChCount) {
+                bestChCount = chCounts[i];
+                bestCh = static_cast<uint8_t>(i);
+            }
+        }
+        born.channel = bestCh;
+
+        return born;
+    }
+
+    int minOctave = 0;   // lower octave limit (0-based)
+    int maxOctave = 7;   // upper octave limit (0-based)
+    int evolveRate = 4;  // evolve every N frames, power-of-2 (1,2,4,8,16,32)
+    int frameCounter = 0;
+    bool pulseMode = true;  // false=hold (note-on at birth, note-off at death), true=pulse (retrigger every step)
+    bool decay = false;           // unified age system: velocity drops + probability drops with age
+    uint8_t minVelocity = 40;    // floor velocity for newborn cells (1-127)
+    int minProb = 10;            // floor probability % at max age (1-100)
+    int maxNotes = 0;            // max notes per step per channel (0 = unlimited)
+    int notesFiredPerChannel[16] = {}; // per-channel counter, reset each evolution step
+
+    // Dedup system: merge identical {channel, pitch} notes, scale velocity/length/CC by count
+    bool dedup = false;
+    int dedupCC = -1;            // CC number for count modulation (-1 = disabled, 1 = mod wheel)
+
+    static constexpr int kMaxPreEmit = 512;
+    struct PreEmitNote {
+        uint8_t channel;
+        uint8_t midiNote;
+        uint8_t velocity;
+        int cellIndex;       // for setting fired flag + activeNotes
+    };
+    PreEmitNote preEmit[kMaxPreEmit];
+    int preEmitCount = 0;
+
+    // Collect a note into the pre-emit buffer (used when dedup is on)
+    void collectNote(uint8_t ch, uint8_t note, uint8_t vel, int cellIdx) {
+        if (preEmitCount < kMaxPreEmit)
+            preEmit[preEmitCount++] = { ch, note, vel, cellIdx };
+    }
+
+    // Flush pre-emit buffer: merge duplicates, emit with scaled velocity + CC
+    int flushDedup(MidiEvent* outEvents, int maxEvents) {
+        if (preEmitCount == 0) return 0;
+        int eventCount = 0;
+
+        // Simple O(n²) merge — fine for <512 notes
+        struct Merged {
+            uint8_t channel, midiNote;
+            int count;
+            int velSum;          // sum of velocities for averaging
+            int firstCellIndex;  // for fired flag
+            bool emitted;
+        };
+        Merged merged[kMaxPreEmit];
+        int mergedCount = 0;
+
+        for (int i = 0; i < preEmitCount; i++) {
+            auto& n = preEmit[i];
+            // Look for existing entry
+            int found = -1;
+            for (int j = 0; j < mergedCount; j++) {
+                if (merged[j].channel == n.channel && merged[j].midiNote == n.midiNote) {
+                    found = j;
+                    break;
+                }
+            }
+            if (found >= 0) {
+                merged[found].count++;
+                merged[found].velSum += n.velocity;
+            } else {
+                merged[mergedCount++] = { n.channel, n.midiNote, 1, (int)n.velocity, n.cellIndex, false };
+            }
+            // Mark all contributing cells as fired
+            if (n.cellIndex >= 0 && n.cellIndex < w * h)
+                cells[n.cellIndex].fired = true;
+        }
+
+        // Emit deduplicated notes
+        for (int i = 0; i < mergedCount; i++) {
+            auto& m = merged[i];
+            if (!canFireMore(m.channel)) continue;
+
+            // Average velocity preserves age variation, count boost adds headroom
+            int vel = m.velSum / m.count;
+            if (m.count > 1) {
+                // Gentle log scaling: each doubling adds ~15 velocity
+                float boost = std::log2(static_cast<float>(m.count)) * 15.0f;
+                vel = juce::jmin(127, static_cast<int>(vel + boost));
+            }
+
+            // Emit NoteOn
+            if (eventCount < maxEvents) {
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::NoteOn;
+                e.bytes[0] = static_cast<uint8_t>(0x90 + m.channel);
+                e.bytes[1] = m.midiNote;
+                e.bytes[2] = static_cast<uint8_t>(vel);
+                e.numBytes = 3;
+                if (m.firstCellIndex >= 0 && m.firstCellIndex < w * h)
+                    activeNotes[m.firstCellIndex] = { m.channel, m.midiNote, true };
+                notesFiredPerChannel[m.channel & 0x0F]++;
+            }
+
+            // Emit CC proportional to count (0-127 mapped from count 1..16+)
+            if (dedupCC >= 0 && m.count > 1 && eventCount < maxEvents) {
+                int ccVal = juce::jmin(127, (m.count * 127) / 8); // 8 cells = max CC
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::CC;
+                e.bytes[0] = static_cast<uint8_t>(0xB0 + m.channel);
+                e.bytes[1] = static_cast<uint8_t>(dedupCC);
+                e.bytes[2] = static_cast<uint8_t>(ccVal);
+                e.numBytes = 3;
+            }
+        }
+
+        preEmitCount = 0;
+        return eventCount;
+    }
+
+    // Cellular automata rule set using S/B notation (survival/birth)
+    // Stored as bitmasks: bit N = neighbor count N triggers that rule
+    uint16_t birthRule = (1 << 3);               // B3
+    uint16_t survivalRule = (1 << 2) | (1 << 3); // S23
+    char ruleString[16] = "23/3";                // S/B display string
+
+    // Parse S/B notation string like "23/3", "23/36", "34/34"
+    bool setRuleFromString(const char* str) {
+        uint16_t newSurvival = 0, newBirth = 0;
+        const char* p = str;
+        // Parse survival digits (before '/')
+        while (*p && *p != '/') {
+            if (*p >= '0' && *p <= '8')
+                newSurvival |= (1 << (*p - '0'));
+            p++;
+        }
+        if (*p == '/') p++; // skip '/'
+        // Parse birth digits (after '/')
+        while (*p) {
+            if (*p >= '0' && *p <= '8')
+                newBirth |= (1 << (*p - '0'));
+            p++;
+        }
+        if (newBirth == 0 && newSurvival == 0) return false;
+        birthRule = newBirth;
+        survivalRule = newSurvival;
+        // Store display string
+        int len = 0;
+        for (int i = 0; i < 9 && len < 14; i++)
+            if ((survivalRule >> i) & 1) ruleString[len++] = '0' + i;
+        ruleString[len++] = '/';
+        for (int i = 0; i < 9 && len < 14; i++)
+            if ((birthRule >> i) & 1) ruleString[len++] = '0' + i;
+        ruleString[len] = '\0';
+        return true;
+    }
+
+    // Named presets
+    void setRulePreset(const char* name) {
+        if (strcmp(name, "life") == 0)           setRuleFromString("23/3");
+        else if (strcmp(name, "highlife") == 0)  setRuleFromString("23/36");
+        else if (strcmp(name, "seeds") == 0)     setRuleFromString("/2");
+        else if (strcmp(name, "daynight") == 0)  setRuleFromString("34678/3678");
+        else if (strcmp(name, "diamoeba") == 0)  setRuleFromString("5678/35678");
+        else if (strcmp(name, "replicator") == 0) setRuleFromString("1357/1357");
+        else if (strcmp(name, "2x2") == 0)       setRuleFromString("125/36");
+        else if (strcmp(name, "morley") == 0)    setRuleFromString("245/368");
+        else if (strcmp(name, "34life") == 0)    setRuleFromString("34/34");
+    }
+
+    bool shouldBeBorn(int neighbors) const { return (birthRule >> neighbors) & 1; }
+    bool shouldSurvive(int neighbors) const { return (survivalRule >> neighbors) & 1; }
+    bool firstEvolution = true;  // treat all alive cells as born on first step after start
+
+    // Evolve rate helpers (power-of-2 only)
+    void evolveRateUp()   { if (evolveRate < 32) evolveRate *= 2; }
+    void evolveRateDown() { if (evolveRate > 1)  evolveRate /= 2; }
+
+    // Decay curve: maps cell age to a 0.0–1.0 factor (1.0 = newborn, decays toward 0.0)
+    // Used for both velocity and probability
+    float decayFactor(uint16_t cellAge) const {
+        constexpr uint16_t maxAge = 64;
+        if (cellAge >= maxAge) return 0.0f;
+        return 1.0f - static_cast<float>(cellAge) / static_cast<float>(maxAge);
+    }
+
+    // Velocity: when decay is on, newborn = 127, ages toward minVelocity
+    uint8_t velocityFor(int cellIndex) const {
+        if (!decay) return 100; // default flat velocity
+        float f = decayFactor(cells[cellIndex].age);
+        // Interpolate: maxVel at birth → minVelocity at max age
+        return static_cast<uint8_t>(minVelocity + (int)(f * (127 - minVelocity)));
+    }
+
+    // Probability: when decay is on, newborn = 100%, ages toward minProb%
+    bool shouldFire(int cellIndex) const {
+        if (!decay) return true;
+        float f = decayFactor(cells[cellIndex].age);
+        // Interpolate: 100% at birth → minProb% at max age
+        int effectiveProb = minProb + (int)(f * (100 - minProb));
+        if (effectiveProb >= 100) return true;
+        return (std::rand() % 100) < effectiveProb;
+    }
+
+    // Density thinning: check if we've hit the per-channel note cap
+    bool canFireMore(uint8_t channel) const {
+        if (maxNotes <= 0) return true;
+        return notesFiredPerChannel[channel & 0x0F] < maxNotes;
+    }
+
+    // Row phase offset: stagger note emission across the evolve cycle by row
+    enum SeqMode { SeqOff = 0, SeqForward, SeqReverse, SeqMirror, SeqRandom };
+    SeqMode seqMode = SeqOff;
+
+    // Mirror ping-pong state: flips direction each evolution cycle
+    bool mirrorForward = true;
+
+    // Random permutation table for SeqRandom (row → phase frame mapping)
+    int randomPhase[512]; // maps row group → frame (regenerated each evolution)
+    void shufflePhaseTable() {
+        int groups = evolveRate;
+        for (int i = 0; i < groups; i++) randomPhase[i] = i;
+        // Fisher-Yates shuffle
+        for (int i = groups - 1; i > 0; i--) {
+            int j = std::rand() % (i + 1);
+            int tmp = randomPhase[i];
+            randomPhase[i] = randomPhase[j];
+            randomPhase[j] = tmp;
+        }
+    }
+
+    bool lockOctave = false; // born cells inherit parent octave (no octave shifts from scale stepping)
+    // Chord degree filter: which scale degrees are allowed (1-indexed, stored as 0-indexed bitmask)
+    // e.g. "135" = root+3rd+5th, "1357" = seventh chord, "0" or empty = off
+    int chordDegrees[7] = { 0, 2, 4 }; // default: 1st, 3rd, 5th (stored as 0-indexed)
+    int chordDegreeCount = 0;           // 0 = chord filter off
+
+    // Set chord degrees from a string like "135", "1357", "125", "off"
+    void setChordDegrees(const char* str) {
+        if (str[0] == '0' || str[0] == '\0') { chordDegreeCount = 0; return; } // off
+        chordDegreeCount = 0;
+        for (const char* p = str; *p && chordDegreeCount < 7; p++) {
+            if (*p >= '1' && *p <= '7')
+                chordDegrees[chordDegreeCount++] = (*p - '1'); // convert 1-indexed to 0-indexed
+        }
+        if (chordDegreeCount == 0) return; // nothing valid parsed
+    }
+
+    // Get chord degrees as display string (1-indexed)
+    juce::String chordDegreesString() const {
+        if (chordDegreeCount == 0) return "off";
+        juce::String s;
+        for (int i = 0; i < chordDegreeCount; i++)
+            s += juce::String(chordDegrees[i] + 1);
+        return s;
+    }
+
+    // Snap a MIDI note to the nearest allowed chord tone
+    int snapToChordTone(int midiNote) const {
+        if (chordDegreeCount == 0) return midiNote;
+        int sLen = scaleLengths[static_cast<int>(currentScale)];
+        const int* s = scaleNotes[static_cast<int>(currentScale)];
+        // If scale has fewer notes than max requested degree, skip filtering
+        int maxDegree = 0;
+        for (int i = 0; i < chordDegreeCount; i++)
+            if (chordDegrees[i] > maxDegree) maxDegree = chordDegrees[i];
+        if (sLen <= maxDegree) return midiNote;
+
+        // Build allowed semitones from the selected degrees
+        int allowedSemitones[7];
+        for (int i = 0; i < chordDegreeCount; i++)
+            allowedSemitones[i] = s[chordDegrees[i]];
+
+        // Find nearest allowed tone to this MIDI note
+        int bestNote = midiNote;
+        int bestDist = 999;
+        for (int octShift = -1; octShift <= 1; octShift++) {
+            for (int i = 0; i < chordDegreeCount; i++) {
+                int base = midiNote - ((midiNote - 24 - rootNote) % 12 + 12) % 12;
+                int candidate = base + allowedSemitones[i] + octShift * 12;
+                int dist = std::abs(candidate - midiNote);
+                if (dist < bestDist && candidate >= 0 && candidate <= 127) {
+                    bestDist = dist;
+                    bestNote = candidate;
+                }
+            }
+        }
+        return bestNote;
+    }
+
+    int phaseForRow(int y) const {
+        if (seqMode == SeqOff || evolveRate <= 1 || wrapH <= 0) return 0;
+        int forwardPhase = y * evolveRate / wrapH;
+        switch (seqMode) {
+            case SeqForward: return forwardPhase;
+            case SeqReverse: return (evolveRate - 1) - forwardPhase;
+            case SeqMirror:
+                // Ping-pong: alternates forward/reverse each cycle
+                return mirrorForward ? forwardPhase : (evolveRate - 1) - forwardPhase;
+            case SeqRandom: return randomPhase[forwardPhase % evolveRate];
+            default: return 0;
+        }
+    }
+
+    // Phase-scheduled notes (emitted on intermediate frames when phaseOffset is active)
+    static constexpr int kMaxPhaseNotes = 1024;
+    struct PhaseNote {
+        uint8_t midiNote;
+        uint8_t channel;
+        uint8_t velocity;
+        int phaseFrame;   // which frameCounter value to fire on (1..evolveRate-1)
+        int cellIndex;    // for setting fired flag + activeNotes tracking
+    };
+    PhaseNote phaseNotes[kMaxPhaseNotes];
+    int phaseNoteCount = 0;
+
+    int processPhaseNotes(int currentFrame, MidiEvent* outEvents, int maxEvents) {
+        int eventCount = 0;
+        int phaseNotesPerCh[16] = {};
+        for (int i = 0; i < phaseNoteCount; i++) {
+            auto& pn = phaseNotes[i];
+            if (pn.phaseFrame != currentFrame) continue;
+            if (eventCount >= maxEvents) break;
+
+            // Per-phase maxNotes check
+            if (maxNotes > 0 && phaseNotesPerCh[pn.channel & 0x0F] >= maxNotes) continue;
+
+            auto& e = outEvents[eventCount++];
+            e.type = MidiEvent::NoteOn;
+            e.bytes[0] = static_cast<uint8_t>(0x90 + pn.channel);
+            e.bytes[1] = pn.midiNote;
+            e.bytes[2] = pn.velocity;
+            e.numBytes = 3;
+
+            phaseNotesPerCh[pn.channel & 0x0F]++;
+            if (pn.cellIndex >= 0 && pn.cellIndex < w * h) {
+                cells[pn.cellIndex].fired = true;
+                activeNotes[pn.cellIndex] = { pn.channel, pn.midiNote, true };
+            }
+        }
+        return eventCount;
+    }
+
+    // Ratchet system (pulse mode only): clusters of same-note cells fire sequentially
+    static constexpr int kMaxRatchets = 128;
+    struct Ratchet {
+        uint8_t midiNote;   // MIDI pitch
+        uint8_t channel;
+        uint8_t remaining;  // notes left to fire (including current)
+        bool activeNote;    // is a note currently sounding from this ratchet?
+        uint8_t velocity;   // velocity for ratchet notes
+    };
+    Ratchet ratchets[kMaxRatchets];
+    int ratchetCount = 0;
+
+    // Run one Game of Life step, emit MIDI events directly
+    int step(MidiEvent* outEvents, int maxEvents) {
+        int eventCount = 0;
+
+        // Only evolve every N frames
+        frameCounter++;
+        if (frameCounter < evolveRate) {
+            // Process pending ratchets and phase-scheduled notes on intermediate frames
+            eventCount += processRatchets(outEvents, maxEvents);
+            if (seqMode != SeqOff)
+                eventCount += processPhaseNotes(frameCounter, outEvents + eventCount, maxEvents - eventCount);
+            generation++;
+            return eventCount;
+        }
+        frameCounter = 0;
+        memset(notesFiredPerChannel, 0, sizeof(notesFiredPerChannel));
+        phaseNoteCount = 0;
+        preEmitCount = 0;
+        if (seqMode == SeqRandom) shufflePhaseTable();
+        if (seqMode == SeqMirror) mirrorForward = !mirrorForward;
+
+        // Clear fired flags from previous step
+        for (int i = 0; i < w * h; i++)
+            cells[i].fired = false;
+
+        // Silence any pending ratchet notes before next evolution
+        eventCount += silenceRatchets(outEvents + eventCount, maxEvents - eventCount);
+        ratchetCount = 0;
+
+        // Auto-save initial state before first evolution
+        if (!hasInitialState && population() > 0)
+            saveInitialState();
+
+        // Snapshot current state
+        memcpy(buffer, cells, sizeof(LifeCell) * w * h);
+
+        // In pulse mode, silence all active notes before applying rules
+        if (pulseMode)
+            eventCount += silence(outEvents + eventCount, maxEvents - eventCount);
+
+        // Apply GoL rules (only within visible/wrap boundary)
+        for (int y = 0; y < wrapH; y++) {
+            for (int x = 0; x < wrapW; x++) {
+                int idx = x + w * y;
+                int neighbors = countNeighbors(x, y);
+                bool wasAlive = buffer[idx].alive;
+
+                if (wasAlive) {
+                    if (!shouldSurvive(neighbors) && !buffer[idx].locked) {
+                        // Death (protected cells are immune)
+                        cells[idx].alive = false;
+                        cells[idx].note = '.';
+                        cells[idx].age = 0;
+
+                        // Emit note-off (hold mode only; pulse already silenced above)
+                        if (!pulseMode && activeNotes[idx].active && eventCount < maxEvents) {
+                            auto& e = outEvents[eventCount++];
+                            e.type = MidiEvent::NoteOff;
+                            e.bytes[0] = static_cast<uint8_t>(0x80 + activeNotes[idx].channel);
+                            e.bytes[1] = activeNotes[idx].midiNote;
+                            e.bytes[2] = 0;
+                            e.numBytes = 3;
+                            activeNotes[idx].active = false;
+                        }
+                    } else {
+                        // Survival — increment age
+                        if (decay)
+                            cells[idx].age = buffer[idx].age + 1;
+                    }
+                } else {
+                    if (shouldBeBorn(neighbors)) {
+                        // Birth
+                        LifeCell born = deriveBirthCell(x, y);
+                        born.age = 0;
+                        cells[idx] = born;
+                    }
+                }
+            }
+        }
+
+        if (pulseMode && evolveRate > 1 && seqMode == SeqOff) {
+            // Cluster detection + ratchet scheduling
+            // clusterTag: 0 = unvisited, >0 = cluster ID (uses member buffer)
+            int16_t* clusterTag = clusterTagBuf;
+            memset(clusterTag, 0, sizeof(int16_t) * w * h);
+            int nextCluster = 1;
+
+            for (int wy = 0; wy < wrapH; wy++) {
+            for (int wx = 0; wx < wrapW; wx++) {
+                int i = wx + w * wy;
+                if (!cells[i].alive || clusterTag[i] != 0) continue;
+
+                // Flood fill orthogonally for same-note, same-channel cells
+                char cNote = cells[i].note;
+                uint8_t cCh = cells[i].channel;
+                uint8_t cOct = cells[i].octave;
+                int tag = nextCluster++;
+                int clusterSize = 0;
+
+                // Simple stack-based flood fill (uses member buffer)
+                int* stack = floodStack;
+                int stackTop = 0;
+                stack[stackTop++] = i;
+                clusterTag[i] = static_cast<int16_t>(tag);
+
+                while (stackTop > 0) {
+                    int ci = stack[--stackTop];
+                    clusterSize++;
+                    int cx = ci % w, cy = ci / w;
+                    // Check 4 orthogonal neighbors (within wrap boundary)
+                    const int ddx[] = {-1, 1, 0, 0};
+                    const int ddy[] = {0, 0, -1, 1};
+                    for (int d = 0; d < 4; d++) {
+                        int nx = cx + ddx[d], ny = cy + ddy[d];
+                        if (nx < 0 || nx >= wrapW || ny < 0 || ny >= wrapH) continue;
+                        int ni = nx + w * ny;
+                        if (clusterTag[ni] != 0 || !cells[ni].alive) continue;
+                        if (cells[ni].note != cNote || cells[ni].channel != cCh) continue;
+                        clusterTag[ni] = static_cast<int16_t>(tag);
+                        stack[stackTop++] = ni;
+                    }
+                }
+
+                // Create ratchet or immediate note based on cluster size
+                auto tr = transpose(cNote, cOct);
+                if (!tr.valid || tr.id <= 0) continue;
+                tr.id = snapToChordTone(tr.id);
+
+                // Probability + density gates
+                if (!canFireMore(cCh) || !shouldFire(i)) continue;
+
+                if (dedup) {
+                    // Dedup mode: collect all cluster cells individually for merging
+                    uint8_t vel = velocityFor(i);
+                    collectNote(cCh, static_cast<uint8_t>(tr.id), vel, i);
+                    // Also collect other cluster cells (they share the same note)
+                    for (int cy2 = 0; cy2 < wrapH; cy2++)
+                        for (int cx2 = 0; cx2 < wrapW; cx2++) {
+                            int ci2 = cx2 + w * cy2;
+                            if (ci2 != i && clusterTag[ci2] == tag)
+                                collectNote(cCh, static_cast<uint8_t>(tr.id), velocityFor(ci2), ci2);
+                        }
+                } else if (clusterSize > 1 && ratchetCount < kMaxRatchets) {
+                    // Schedule ratchet: first note fires now, rest on subsequent frames
+                    int ratchetNotes = clusterSize;
+                    if (ratchetNotes > evolveRate - 1) ratchetNotes = evolveRate - 1; // cap to fit
+
+                    // Fire first ratchet note immediately
+                    uint8_t vel = velocityFor(i);
+                    if (eventCount < maxEvents) {
+                        auto& e = outEvents[eventCount++];
+                        e.type = MidiEvent::NoteOn;
+                        e.bytes[0] = static_cast<uint8_t>(0x90 + cCh);
+                        e.bytes[1] = static_cast<uint8_t>(tr.id);
+                        e.bytes[2] = vel;
+                        e.numBytes = 3;
+                        cells[i].fired = true;
+                        notesFiredPerChannel[cCh & 0x0F]++;
+                    }
+
+                    ratchets[ratchetCount++] = {
+                        static_cast<uint8_t>(tr.id), cCh,
+                        static_cast<uint8_t>(ratchetNotes - 1), // remaining after first
+                        true, vel
+                    };
+
+                    // Mark all cluster cells so they don't fire individually
+                    // (clusterTag already marks them, we skip tagged cells below)
+                } else if (clusterSize == 1) {
+                    // Single cell: fire normally
+                    if (eventCount < maxEvents) {
+                        auto& e = outEvents[eventCount++];
+                        e.type = MidiEvent::NoteOn;
+                        e.bytes[0] = static_cast<uint8_t>(0x90 + cCh);
+                        e.bytes[1] = static_cast<uint8_t>(tr.id);
+                        e.bytes[2] = velocityFor(i);
+                        e.numBytes = 3;
+                        activeNotes[i] = { cCh, static_cast<uint8_t>(tr.id), true };
+                        cells[i].fired = true;
+                        notesFiredPerChannel[cCh & 0x0F]++;
+                    }
+                }
+            } // wx
+            } // wy
+        } else {
+            // Non-ratchet path: emit note-ons (with optional phase scheduling)
+            for (int yy = 0; yy < wrapH; yy++) {
+            int rowPhase = phaseForRow(yy);
+            for (int xx = 0; xx < wrapW; xx++) {
+                int i = xx + w * yy;
+                if (!cells[i].alive) continue;
+                bool wasBorn = !buffer[i].alive || firstEvolution;
+                if (!wasBorn && !pulseMode) continue;
+
+                // Probability gate (applies to all modes)
+                if (!shouldFire(i)) continue;
+
+                auto tr = transpose(cells[i].note, cells[i].octave);
+                if (!tr.valid || tr.id <= 0) continue;
+                tr.id = snapToChordTone(tr.id);
+
+                // Phase offset: schedule for later frame (maxNotes checked in processPhaseNotes)
+                if (rowPhase > 0 && phaseNoteCount < kMaxPhaseNotes) {
+                    phaseNotes[phaseNoteCount++] = {
+                        static_cast<uint8_t>(tr.id),
+                        cells[i].channel,
+                        velocityFor(i),
+                        rowPhase, i
+                    };
+                    continue;
+                }
+
+                if (dedup) {
+                    // Dedup mode: collect for merging
+                    collectNote(cells[i].channel, static_cast<uint8_t>(tr.id), velocityFor(i), i);
+                } else {
+                    // Density gate (phase-0 notes in seq mode, or all notes in normal mode)
+                    if (!canFireMore(cells[i].channel)) continue;
+
+                    if (eventCount < maxEvents) {
+                        auto& e = outEvents[eventCount++];
+                        e.type = MidiEvent::NoteOn;
+                        e.bytes[0] = static_cast<uint8_t>(0x90 + cells[i].channel);
+                        e.bytes[1] = static_cast<uint8_t>(tr.id);
+                        e.bytes[2] = velocityFor(i);
+                        e.numBytes = 3;
+                        activeNotes[i] = { cells[i].channel, static_cast<uint8_t>(tr.id), true };
+                        cells[i].fired = true;
+                        notesFiredPerChannel[cells[i].channel & 0x0F]++;
+                    }
+                }
+            } // xx
+            } // yy
+        }
+
+        // Flush dedup buffer if active
+        if (dedup && preEmitCount > 0)
+            eventCount += flushDedup(outEvents + eventCount, maxEvents - eventCount);
+
+        firstEvolution = false;
+        generation++;
+        return eventCount;
+    }
+
+    // Process pending ratchets (called on non-evolve frames)
+    int processRatchets(MidiEvent* outEvents, int maxEvents) {
+        int eventCount = 0;
+        for (int r = 0; r < ratchetCount; r++) {
+            auto& rch = ratchets[r];
+            if (rch.remaining == 0) continue;
+
+            // Silence previous ratchet note
+            if (rch.activeNote && eventCount < maxEvents) {
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::NoteOff;
+                e.bytes[0] = static_cast<uint8_t>(0x80 + rch.channel);
+                e.bytes[1] = rch.midiNote;
+                e.bytes[2] = 0;
+                e.numBytes = 3;
+            }
+
+            // Fire next ratchet note
+            if (eventCount < maxEvents) {
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::NoteOn;
+                e.bytes[0] = static_cast<uint8_t>(0x90 + rch.channel);
+                e.bytes[1] = rch.midiNote;
+                e.bytes[2] = rch.velocity;
+                e.numBytes = 3;
+                rch.activeNote = true;
+            }
+            rch.remaining--;
+        }
+        return eventCount;
+    }
+
+    // Silence any currently sounding ratchet notes
+    int silenceRatchets(MidiEvent* outEvents, int maxEvents) {
+        int eventCount = 0;
+        for (int r = 0; r < ratchetCount; r++) {
+            if (ratchets[r].activeNote && eventCount < maxEvents) {
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::NoteOff;
+                e.bytes[0] = static_cast<uint8_t>(0x80 + ratchets[r].channel);
+                e.bytes[1] = ratchets[r].midiNote;
+                e.bytes[2] = 0;
+                e.numBytes = 3;
+                ratchets[r].activeNote = false;
+            }
+        }
+        return eventCount;
+    }
+
+    // Silence all active notes
+    int silence(MidiEvent* outEvents, int maxEvents) {
+        int eventCount = 0;
+        for (int i = 0; i < w * h; i++) {
+            if (activeNotes[i].active && eventCount < maxEvents) {
+                auto& e = outEvents[eventCount++];
+                e.type = MidiEvent::NoteOff;
+                e.bytes[0] = static_cast<uint8_t>(0x80 + activeNotes[i].channel);
+                e.bytes[1] = activeNotes[i].midiNote;
+                e.bytes[2] = 0;
+                e.numBytes = 3;
+                activeNotes[i].active = false;
+            }
+        }
+        return eventCount;
+    }
+
+    // Trigger note-ons for all alive cells (used on transport restart)
+    int triggerAlive(MidiEvent* outEvents, int maxEvents) {
+        int eventCount = 0;
+        for (int i = 0; i < w * h; i++) {
+            if (cells[i].alive && !activeNotes[i].active) {
+                auto tr = transpose(cells[i].note, cells[i].octave);
+                tr.id = snapToChordTone(tr.id);
+                if (tr.valid && tr.id > 0 && eventCount < maxEvents) {
+                    auto& e = outEvents[eventCount++];
+                    e.type = MidiEvent::NoteOn;
+                    e.bytes[0] = static_cast<uint8_t>(0x90 + cells[i].channel);
+                    e.bytes[1] = static_cast<uint8_t>(tr.id);
+                    e.bytes[2] = velocityFor(i);
+                    e.numBytes = 3;
+                    activeNotes[i] = { cells[i].channel, static_cast<uint8_t>(tr.id), true };
+                }
+            }
+        }
+        return eventCount;
+    }
+
+    // Initial state snapshot for reset
+    LifeCell initialState[kMaxGridSize];
+    int initialW = 0, initialH = 0; // dimensions when snapshot was taken
+    bool hasInitialState = false;
+
+    void saveInitialState() {
+        memcpy(initialState, cells, sizeof(LifeCell) * w * h);
+        initialW = w;
+        initialH = h;
+        hasInitialState = true;
+    }
+
+    int resetToInitial(MidiEvent* outEvents, int maxEvents) {
+        int eventCount = silence(outEvents, maxEvents);
+        if (hasInitialState) {
+            // Clear all cells first
+            for (int i = 0; i < w * h; i++) {
+                cells[i] = LifeCell();
+                activeNotes[i] = { 0, 0, false };
+            }
+            // Copy back with stride conversion if storage dimensions changed
+            int copyW = (initialW < w) ? initialW : w;
+            int copyH = (initialH < h) ? initialH : h;
+            for (int y = 0; y < copyH; y++)
+                for (int x = 0; x < copyW; x++)
+                    cells[x + w * y] = initialState[x + initialW * y];
+        }
+        generation = 0;
+        frameCounter = 0;
+        firstEvolution = true;
+        phaseNoteCount = 0;
+        mirrorForward = true;
+        memset(notesFiredPerChannel, 0, sizeof(notesFiredPerChannel));
+        return eventCount;
+    }
+
+    int population() const {
+        int count = 0;
+        for (int i = 0; i < w * h; i++)
+            if (cells[i].alive) count++;
+        return count;
+    }
+
+private:
+    // Scratch buffers for cluster detection in step() — heap-allocated as class
+    // members to avoid 384KB stack allocations on the audio thread.
+    int16_t clusterTagBuf[kMaxGridSize];
+    int floodStack[kMaxGridSize];
+};
+
+} // namespace orca

--- a/plugin/Source/engine/Operator.cpp
+++ b/plugin/Source/engine/Operator.cpp
@@ -190,7 +190,8 @@ void OperatorInstance::operation(Grid& grid, EngineIO& io, bool force,
         int rate = static_cast<int>(listen(grid, ports[PRate], true));
         int mod = static_cast<int>(listen(grid, ports[PMod], true));
         if (rate == 0) rate = 1;
-        int val = mod > 0 ? (grid.f / rate) % mod : 0;
+        if (mod == 0) { hasResult = false; break; } // match JS: % 0 = NaN → no output
+        int val = (grid.f / rate) % mod;
         result = keyOf(val);
         hasResult = true;
         break;
@@ -560,26 +561,65 @@ void OperatorInstance::operation(Grid& grid, EngineIO& io, bool force,
         break;
     }
 
-    case OpType::Osc: // = (no-op in plugin)
-    case OpType::Udp: // ; (no-op in plugin)
-    {
-        // Lock eastward glyphs until '.'
+    case OpType::Osc: { // =
+        // Port 0 at (1,0) is path char, data starts at x+2
+        char pathChar = grid.glyphAt(x + 1, y);
+        grid.lock(x + 1, y);
+
+        char oscBuf[64];
+        int oscLen = 0;
+        for (int lx = 2; lx <= 36; lx++) {
+            char g = grid.glyphAt(x + lx, y);
+            grid.lock(x + lx, y);
+            if (g == '.') break;
+            if (oscLen < 62) oscBuf[oscLen++] = g;
+        }
+        oscBuf[oscLen] = '\0';
+
+        if (!hasNeighbor(grid, '*') && !force) break;
+        if (pathChar == '.' || pathChar == '*') break;
+
+        io.pushOsc(pathChar, oscBuf, oscLen);
+        draw = false;
+        break;
+    }
+
+    case OpType::Udp: { // ;
+        // Collect eastward glyphs as raw message
+        char udpBuf[64];
+        int udpLen = 0;
         for (int lx = 1; lx <= 36; lx++) {
             char g = grid.glyphAt(x + lx, y);
             grid.lock(x + lx, y);
             if (g == '.') break;
+            if (udpLen < 63) udpBuf[udpLen++] = g;
         }
+        udpBuf[udpLen] = '\0';
+
+        if (!hasNeighbor(grid, '*') && !force) break;
+
+        io.pushUdp(udpBuf, udpLen);
+        draw = false;
         break;
     }
 
     case OpType::Self: { // $
-        // Lock eastward glyphs until '.'
+        // Lock eastward glyphs until '.', collect into command string
+        char cmdBuf[64];
+        int cmdLen = 0;
         for (int lx = 1; lx <= 36; lx++) {
             char g = grid.glyphAt(x + lx, y);
             grid.lock(x + lx, y);
             if (g == '.') break;
+            if (cmdLen < 63) cmdBuf[cmdLen++] = g;
         }
-        // No-op in plugin context (would need commander)
+        cmdBuf[cmdLen] = '\0';
+
+        if (!hasNeighbor(grid, '*') && !force) break;
+        if (cmdLen == 0) break;
+
+        draw = false;
+        io.pushCommand(cmdBuf, cmdLen);
         break;
     }
 


### PR DESCRIPTION
## Summary

- **JUCE AU/VST3 plugin** with native C++ engine, virtual MIDI port, UDP/OSC output, and full operator parity with the JS desktop version
- **Game of Life sequencer mode** — cellular automaton where alive cells trigger MIDI notes, with musical scales, decay, chord filters, dedup, sequencer row scanning (forward/reverse/mirror/random), and configurable CA rules (Conway, HighLife, Seeds, etc.)
- **17 DAW-automatable parameters** via APVTS for evolve rate, scale, root, seq mode, chord filter, decay, octave range, dedup, and more
- **New operators**: chord (]), humanize (>), ratchet (<), swing (\), probability (~), scale (^), buffer ({), freeze (}), gate (|), arp (&), markov (@), strum ([)
- **Groove/shuffle system** with DAW-automatable swing parameter and custom ratio patterns
- **48 classic GoL patterns** across 6 categories (still lifes, oscillators, spaceships, methuselahs, guns, puffers)