### PR TITLE
Add deflect operator, clean/autoclean, and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ To display the list of operators inside of Orca, use `CmdOrCtrl+G`.
 - `>` **humanize**(max): On bang, delays the output bang by a random 0-max frames. State stored in south cell, bang output one cell below.
 - `<` **ratchet**(subdivisions period): On bang, outputs N evenly-spaced bangs over the given period of frames. State stored in south cell, bang output one cell below.
 - `\` **swing**(delay): Alternates between immediate and delayed bangs. Odd bangs pass through instantly, even bangs are delayed by N frames. Uses 3 south cells (toggle, countdown, output).
+- `/` **deflect**: Redirects adjacent movers (N/S/E/W) to point away. Any mover next to `/` gets rewritten to face outward — e.g. `S` to the east of `/` becomes `E`, `S` above `/` becomes `N`. Works as a passive obstacle that redirects instead of destroying. Preserves uppercase/lowercase.
 
 ## MIDI
 
@@ -293,6 +294,8 @@ All commands support 2-letter shorthands (first two characters).
 | `time` | `ti` | Write current time at cursor |
 | `color:f00;0f0;00f` | `cl` | Set theme colors (bLow;bMed;bHigh as hex RGB) |
 | `inject:name` | `in` | Inject cached module at cursor (or `inject:name;x;y`) |
+| `clean` | -- | Remove all movers (N/S/E/W) and bangs (*) from grid (skips halted) |
+| `autoclean` | -- | Toggle auto-clean on transport stop (`autoclean:on`/`off`) |
 
 **Network commands:**
 

--- a/plugin/Source/PluginEditor.cpp
+++ b/plugin/Source/PluginEditor.cpp
@@ -170,54 +170,61 @@ void GridComponent::paint(juce::Graphics& g) {
                    getWidth() - 8, 14, juce::Justification::centredLeft);
     } else if (engine.lifeMode) {
         // Life mode status bar
-        // Line 1: LIFE  ch:X  oct:X  cursor_pos  generation
+        // Line 1: mode, real-time state, musical context
         {
             g.setColour(juce::Colour(channelColorValues[engine.paintChannel % 16]));
             juce::String line1;
-            line1 << "LIFE  ch:" << (int)engine.paintChannel
+            line1 << "LIFE   " << cursorX << "," << cursorY
+                  << "   gen:" << engine.shadowF
+                  << "  pop:" << engine.lifeGrid.population()
+                  << "  ch:" << (int)engine.paintChannel
                   << "  oct:" << (int)engine.paintOctave
                   << "  " << orca::LifeGrid::rootNoteName(engine.lifeGrid.rootNote)
                   << " " << orca::LifeGrid::scaleName(engine.lifeGrid.currentScale)
                   << "  " << (engine.lifeGrid.pulseMode ? "pulse" : "hold")
-                  << "  rate:" << engine.lifeGrid.evolveRate
-                  << (engine.lifeGrid.decay ? juce::String("  decay:") + juce::String((int)engine.lifeGrid.minVelocity) + "v/" + juce::String(engine.lifeGrid.minProb) + "%" : juce::String())
-                  << (engine.lifeGrid.maxNotes > 0 ? juce::String("  max:") + juce::String(engine.lifeGrid.maxNotes) : juce::String())
-                  << (engine.lifeGrid.seqMode == orca::LifeGrid::SeqForward ? "  seq" :
+                  << "  rate:" << engine.lifeGrid.evolveRate;
+            line1 << (engine.lifeGrid.seqMode == orca::LifeGrid::SeqForward ? "  seq" :
                       engine.lifeGrid.seqMode == orca::LifeGrid::SeqReverse ? "  seq:rev" :
                       engine.lifeGrid.seqMode == orca::LifeGrid::SeqMirror ? "  seq:mirror" :
-                      engine.lifeGrid.seqMode == orca::LifeGrid::SeqRandom ? "  seq:random" : "")
-                  << (engine.lifeGrid.lockOctave ? "  lockoct" : "")
-                  << (engine.lifeGrid.chordDegreeCount > 0 ? juce::String("  chord:") + engine.lifeGrid.chordDegreesString() : juce::String())
-                  << (engine.lifeGrid.dedup ? juce::String("  dedup") + (engine.lifeGrid.dedupCC >= 0 ? juce::String(" cc:") + juce::String(engine.lifeGrid.dedupCC) : juce::String()) : juce::String())
-                  << (engine.lifeGrid.conductorMode ? "  conductor" : "")
-                  << (engine.lifeGrid.microtuning ? juce::String("  microtune:") + juce::String(engine.lifeGrid.microtuneAmount) : juce::String())
-                  << (engine.lifeGrid.loopState == orca::LifeGrid::LoopRecording ?
-                      juce::String("  loop:rec ") + juce::String(engine.lifeGrid.loopHead) + "/" + juce::String(engine.lifeGrid.loopLength) :
-                      engine.lifeGrid.loopState == orca::LifeGrid::LoopPlaying ?
-                      juce::String("  loop:") + juce::String(engine.lifeGrid.loopHead + 1) + "/" + juce::String(engine.lifeGrid.loopRecorded) :
-                      juce::String())
-                  << (strcmp(engine.lifeGrid.ruleString, "23/3") != 0 ? juce::String("  rule:") + juce::String(engine.lifeGrid.ruleString) : juce::String())
-                  << ((engine.lifeGrid.minOctave != 0 || engine.lifeGrid.maxOctave != 7) ?
-                      juce::String("  oct:") + juce::String(engine.lifeGrid.minOctave) + "-" + juce::String(engine.lifeGrid.maxOctave) :
-                      juce::String())
-                  << "   " << cursorX << "," << cursorY
-                  << "   gen:" << engine.shadowF;
-            {
-            }
-            if (stampMode)
-                line1 << "   STAMP: " << stampCategories[stampCategory].name
-                      << " > " << orca::builtInPatterns[stampIndex].name;
+                      engine.lifeGrid.seqMode == orca::LifeGrid::SeqRandom ? "  seq:random" : "");
+            if (engine.lifeGrid.conductorMode) line1 << "  cond";
+            if (engine.lifeGrid.chordDegreeCount > 0)
+                line1 << "  chd:" << engine.lifeGrid.chordDegreesString();
+            if (engine.lifeGrid.maxNotes > 0)
+                line1 << "  max:" << engine.lifeGrid.maxNotes;
             g.drawText(line1, 4, (int)statusY, getWidth() - 8, 14,
                        juce::Justification::centredLeft);
         }
-        // Line 2: grid_size  population
+        // Line 2: grid info, cursor, network, active modifiers (or stamp overlay)
         {
             g.setColour(fLow);
             juce::String line2;
-            line2 << gridW << "x" << gridH
-                  << "   pop:" << engine.lifeGrid.population()
-                  << "   udp:" << processor.udpOutputPort
-                  << "  osc:" << processor.oscOutputPort;
+            if (stampMode) {
+                line2 << "STAMP: " << stampCategories[stampCategory].name
+                      << " > " << orca::builtInPatterns[stampIndex].name;
+            } else {
+                line2 << gridW << "x" << gridH
+                      << "  udp:" << processor.udpOutputPort
+                      << "  osc:" << processor.oscOutputPort;
+                if (engine.lifeGrid.minOctave != 0 || engine.lifeGrid.maxOctave != 7)
+                    line2 << "  oct:" << engine.lifeGrid.minOctave << "-" << engine.lifeGrid.maxOctave;
+                if (engine.lifeGrid.decay)
+                    line2 << "  dk:" << (int)engine.lifeGrid.minVelocity << "v/" << engine.lifeGrid.minProb << "%";
+                if (engine.lifeGrid.dedup) {
+                    line2 << "  dd";
+                    if (engine.lifeGrid.dedupCC >= 0)
+                        line2 << " cc:" << engine.lifeGrid.dedupCC;
+                }
+                if (engine.lifeGrid.lockOctave) line2 << "  loct";
+                if (engine.lifeGrid.microtuning)
+                    line2 << "  mt:" << engine.lifeGrid.microtuneAmount;
+                if (engine.lifeGrid.loopState == orca::LifeGrid::LoopRecording)
+                    line2 << "  lp:rec " << engine.lifeGrid.loopHead << "/" << engine.lifeGrid.loopLength;
+                else if (engine.lifeGrid.loopState == orca::LifeGrid::LoopPlaying)
+                    line2 << "  lp:" << (engine.lifeGrid.loopHead + 1) << "/" << engine.lifeGrid.loopRecorded;
+                if (strcmp(engine.lifeGrid.ruleString, "23/3") != 0)
+                    line2 << "  rl:" << engine.lifeGrid.ruleString;
+            }
             g.drawText(line2, 4, (int)(statusY + 14), getWidth() - 8, 14,
                        juce::Justification::centredLeft);
         }
@@ -245,7 +252,7 @@ void GridComponent::paint(juce::Graphics& g) {
             } else {
                 line1 << operatorName(curGlyph);
             }
-            line1 << "   " << cursorX << "," << cursorY
+            line1 << "  " << cursorX << "," << cursorY
                   << "   " << engine.shadowF << "f";
             g.drawText(line1, 4, (int)statusY, getWidth() - 8, 14,
                        juce::Justification::centredLeft);
@@ -265,7 +272,9 @@ void GridComponent::paint(juce::Graphics& g) {
             }
             if (!injectCache.empty())
                 line2 << "   " << (int)injectCache.size() << " mods";
-            line2 << "   udp:" << processor.udpOutputPort
+            if (processor.autoClean)
+                line2 << "  autoclean";
+            line2 << "  udp:" << processor.udpOutputPort
                   << "  osc:" << processor.oscOutputPort;
             g.drawText(line2, 4, (int)(statusY + 14), getWidth() - 8, 14,
                        juce::Justification::centredLeft);
@@ -1903,6 +1912,36 @@ bool Commander::trigger(OrcaProcessor& processor, GridComponent& editor) {
             for (int i = 0; i < timeStr.length(); i++)
                 grid.write(editor.cursorX + i, editor.cursorY, (char)timeStr[i]);
         }
+    }
+    else if (!isLife && cmd.name == "clean") {
+        // Remove all movers (N/n/S/s/E/e/W/w) and bangs (*) from the grid
+        // Skip cells halted by H above or after a # comment on the same row
+        const juce::SpinLock::ScopedLockType lock(processor.engineLock);
+        for (int y = 0; y < grid.h; y++) {
+            bool inComment = false;
+            for (int x = 0; x < grid.w; x++) {
+                char g = grid.glyphAt(x, y);
+                if (g == '#') { inComment = true; continue; }
+                if (inComment) continue;
+                if (g == 'N' || g == 'n' || g == 'S' || g == 's' ||
+                    g == 'E' || g == 'e' || g == 'W' || g == 'w' || g == '*') {
+                    if (y > 0) {
+                        char above = grid.glyphAt(x, y - 1);
+                        if (above == 'H' || above == 'h') continue;
+                    }
+                    grid.write(x, y, '.');
+                }
+            }
+        }
+    }
+    else if (!isLife && cmd.name == "autoclean") {
+        auto val = cmd.value.toLowerCase().trim();
+        if (val == "on" || val == "1")
+            processor.autoClean = true;
+        else if (val == "off" || val == "0")
+            processor.autoClean = false;
+        else
+            processor.autoClean = !processor.autoClean;
     }
     else if (cmd.name == "color") {
         // color:f_low;f_med;f_high (hex RGB values)

--- a/plugin/Source/PluginProcessor.cpp
+++ b/plugin/Source/PluginProcessor.cpp
@@ -124,12 +124,18 @@ int OrcaProcessor::findChordPresetIndex(const juce::String& degrees) const {
 
 void OrcaProcessor::syncParamsToLifeGrid() {
     auto& lg = engine.lifeGrid;
-    lg.evolveRate   = lifeRateParam->get();
+    int newRate     = lifeRateParam->get();
+    bool rateChanged = (newRate != lg.evolveRate);
+    lg.evolveRate   = newRate;
     lg.decay        = lifeDecayParam->get();
     lg.minVelocity  = static_cast<uint8_t>(lifeMinVelParam->get());
     lg.minProb      = lifeMinProbParam->get();
     lg.maxNotes     = lifeMaxNotesParam->get();
-    lg.seqMode      = static_cast<orca::LifeGrid::SeqMode>(lifeSeqParam->getIndex());
+    auto newSeqMode  = static_cast<orca::LifeGrid::SeqMode>(lifeSeqParam->getIndex());
+    if (newSeqMode == orca::LifeGrid::SeqRandom &&
+        (lg.seqMode != orca::LifeGrid::SeqRandom || rateChanged))
+        lg.shufflePhaseTable();
+    lg.seqMode      = newSeqMode;
     lg.lockOctave   = lifeLockOctParam->get();
     lg.dedup        = lifeDedupParam->get();
     lg.dedupCC      = lifeDedupCCParam->get();
@@ -291,6 +297,26 @@ void OrcaProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuf
             grooveIndex = 0;
             wasPlaying = false;
             // Silence Life mode notes on stop and reset sequencer phase
+            // Auto-clean movers/bangs from Orca grid on stop
+            if (!engine.lifeMode && autoClean) {
+                auto& g = engine.grid;
+                for (int y = 0; y < g.h; y++) {
+                    bool inComment = false;
+                    for (int x = 0; x < g.w; x++) {
+                        char ch = g.glyphAt(x, y);
+                        if (ch == '#') { inComment = true; continue; }
+                        if (inComment) continue;
+                        if (ch == 'N' || ch == 'n' || ch == 'S' || ch == 's' ||
+                            ch == 'E' || ch == 'e' || ch == 'W' || ch == 'w' || ch == '*') {
+                            if (y > 0) {
+                                char above = g.glyphAt(x, y - 1);
+                                if (above == 'H' || above == 'h') continue;
+                            }
+                            g.write(x, y, '.');
+                        }
+                    }
+                }
+            }
             if (engine.lifeMode) {
                 orca::MidiEvent events[orca::kMaxEvents];
                 int eventCount = 0;
@@ -310,6 +336,11 @@ void OrcaProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuf
             }
         }
         return;
+    }
+    // On transport start: reset frameCounter so first frame hits cycle boundary immediately
+    if (!wasPlaying && engine.lifeMode) {
+        engine.lifeGrid.frameCounter = engine.lifeGrid.evolveRate - 1;
+        engine.lifeGrid.firstEvolution = true;
     }
     // Retrigger alive Life notes on transport start (skip in seq mode — let phase handle it)
     if (!wasPlaying && engine.lifeMode && engine.lifeGrid.seqMode == orca::LifeGrid::SeqOff) {

--- a/plugin/Source/PluginProcessor.h
+++ b/plugin/Source/PluginProcessor.h
@@ -92,6 +92,7 @@ public:
     juce::SpinLock engineLock;
     std::atomic<bool> transportRunning { false };
     std::atomic<bool> standalonePlay { false };
+    bool autoClean = false; // remove movers/bangs on transport stop
 
     // Pending MIDI events from Life mode transitions (UI thread → audio thread)
     static constexpr int kMaxPendingLifeEvents = 64;

--- a/plugin/Source/engine/Engine.h
+++ b/plugin/Source/engine/Engine.h
@@ -143,6 +143,18 @@ public:
                 if (idx >= 0) shadowPorts[idx] = 10; // operator marker
             }
 
+            // Deflector: mark 4 neighbors visually (no ports, render-only)
+            if (op.type == OpType::Deflect) {
+                const int ddx[] = { 0, 1, 0, -1 };
+                const int ddy[] = { -1, 0, 1, 0 };
+                for (int d = 0; d < 4; d++) {
+                    int idx = grid.indexAt(op.x + ddx[d], op.y + ddy[d]);
+                    if (idx >= 0 && shadowPorts[idx] == 0)
+                        shadowPorts[idx] = 2; // input style
+                }
+                continue;
+            }
+
             // Mark ports
             for (int p = 0; p < op.portCount; p++) {
                 if (!op.ports[p].active) continue;

--- a/plugin/Source/engine/Grid.cpp
+++ b/plugin/Source/engine/Grid.cpp
@@ -207,6 +207,36 @@ void Grid::parse() {
 }
 
 void Grid::operate() {
+    // Pre-pass: deflectors redirect adjacent movers before anything moves
+    // Must update both the grid cell AND the OperatorInstance (type + glyph)
+    for (int i = 0; i < runtimeCount; i++) {
+        auto& def = runtime[i];
+        if (def.type != OpType::Deflect) continue;
+        for (int j = 0; j < runtimeCount; j++) {
+            auto& mover = runtime[j];
+            int rx = mover.x - def.x, ry = mover.y - def.y;
+            if ((rx == 0) == (ry == 0)) continue; // must be exactly 1 axis apart
+            if (rx < -1 || rx > 1 || ry < -1 || ry > 1) continue;
+            char gl = (mover.glyph >= 'A' && mover.glyph <= 'Z')
+                      ? (char)(mover.glyph + 32) : mover.glyph;
+            if (gl != 'n' && gl != 'e' && gl != 's' && gl != 'w') continue;
+            bool isUp = (mover.glyph >= 'A' && mover.glyph <= 'Z');
+            OpType newType; char newGlyph;
+            if (rx == 0 && ry == -1) {      // mover is north → point north
+                newType = OpType::N; newGlyph = isUp ? 'N' : 'n';
+            } else if (rx == 1 && ry == 0) { // mover is east → point east
+                newType = OpType::E; newGlyph = isUp ? 'E' : 'e';
+            } else if (rx == 0 && ry == 1) { // mover is south → point south
+                newType = OpType::S; newGlyph = isUp ? 'S' : 's';
+            } else {                          // mover is west → point west
+                newType = OpType::W; newGlyph = isUp ? 'W' : 'w';
+            }
+            mover.type = newType;
+            mover.glyph = newGlyph;
+            write(mover.x, mover.y, newGlyph);
+        }
+    }
+    // Main pass: all operators
     for (int i = 0; i < runtimeCount; i++) {
         auto& op = runtime[i];
         if (lockAt(op.x, op.y)) continue;

--- a/plugin/Source/engine/LifeGrid.h
+++ b/plugin/Source/engine/LifeGrid.h
@@ -597,7 +597,7 @@ public:
     int minOctave = 0;   // lower octave limit (0-based)
     int maxOctave = 7;   // upper octave limit (0-based)
     int evolveRate = 4;  // evolve every N frames, power-of-2 (1,2,4,8,16,32)
-    int frameCounter = 3; // default to evolveRate-1 so first frame hits cycle boundary
+    int frameCounter = 0;
     bool pulseMode = true;  // false=hold (note-on at birth, note-off at death), true=pulse (retrigger every step)
     bool decay = false;           // unified age system: velocity drops + probability drops with age
     uint8_t minVelocity = 40;    // floor velocity for newborn cells (1-127)
@@ -825,7 +825,7 @@ public:
     bool mirrorForward = true;
 
     // Random permutation table for SeqRandom (row → phase frame mapping)
-    int randomPhase[512]; // maps row group → frame (regenerated each evolution)
+    int randomPhase[512] = {}; // maps row group → frame (regenerated each evolution)
     void shufflePhaseTable() {
         int groups = evolveRate;
         for (int i = 0; i < groups; i++) randomPhase[i] = i;
@@ -1014,6 +1014,9 @@ public:
             eventCount += processRatchets(outEvents, maxEvents);
             if (seqMode != SeqOff)
                 eventCount += processPhaseNotes(frameCounter, outEvents + eventCount, maxEvents - eventCount);
+            // Record mid-cycle evolution to loop if armed
+            if (loopState == LoopRecording)
+                loopRecord(outEvents, eventCount);
             generation++;
             return eventCount;
         }

--- a/plugin/Source/engine/Operator.cpp
+++ b/plugin/Source/engine/Operator.cpp
@@ -1029,6 +1029,9 @@ void OperatorInstance::operation(Grid& grid, EngineIO& io, bool force,
         break;
     }
 
+    case OpType::Deflect: // / — uturn: deflection handled in move(), no action needed
+        break;
+
     case OpType::Null:
         break;
 
@@ -1048,7 +1051,7 @@ bool isOperatorGlyph(char g) {
         case '?': case '%': case '=': case ';':
         case '$': case '~': case '^': case '{':
         case '}': case '|': case '&': case '@':
-        case '[': case ']': case '>': case '<': case '\\':
+        case '[': case ']': case '>': case '<': case '\\': case '/':
             return true;
         default:
             return false;
@@ -1366,6 +1369,10 @@ bool createOperator(OperatorInstance& op, char glyph, int x, int y, bool isPassi
         op.init(OpType::SwingGate, x, y, '\\', true);
         op.addPort(0, 1, 0, false, false, false, false, 0, 0, 35);  // delay (east)
         // state cells (toggle, countdown, bang output) at (0,1)-(0,3) managed directly in operation()
+        return true;
+
+    case '/':
+        op.init(OpType::Deflect, x, y, '/', true);
         return true;
     }
 

--- a/plugin/Source/engine/Operator.h
+++ b/plugin/Source/engine/Operator.h
@@ -14,7 +14,7 @@ enum class OpType : uint8_t {
     Bang, Comment,
     Midi, CC, PitchBend, Mono, Osc, Udp, Self,
     Probability, Scale, Buffer, Freeze, Gate, Arp, Markov, Chord,
-    Humanize, Ratchet, SwingGate, Strum,
+    Humanize, Ratchet, SwingGate, Strum, Deflect,
     Null, // digit placeholders
     Count
 };


### PR DESCRIPTION
## Summary
- **`/` deflect operator**: redirects adjacent movers (N/S/E/W) to point away — like the original Orca U-turn operator. Runs in a pre-pass before other operators to ensure correct execution order.
- **`clean` command**: removes stray movers and bangs from the grid, respecting `H` (halt) and `#` (comment) protection.
- **`autoclean` command**: toggleable auto-clean on transport stop.
- **Bug fixes**: first seq cycle silent on play, loop recording missed mid-cycle conductor triggers, seq:random separators not updating on mode/rate change, status bar layout improvements, loop command parsing fix.

## Test plan
- [x] Place `/` on grid, send N/S/E/W movers from all 4 directions — verify they redirect away
- [x] Verify `/` shows highlighted neighbor cells
- [x] Type `clean` in commander after playback — verify movers removed, halted and commented movers preserved
- [x] Toggle `autoclean` and verify movers are cleaned on transport stop
- [ ] Start playback in Life mode with seq — verify first cycle produces sound
- [ ] Use conductor + loop recording — verify Enter triggers record mid-cycle
- [ ] Switch to seq:random — verify separators appear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)